### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -2,6 +2,8 @@
 # https://github.com/firebase/firebase-tools
 
 name: Deploy to Firebase Hosting on merge
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/OrF8/ExpenseManagement/security/code-scanning/2](https://github.com/OrF8/ExpenseManagement/security/code-scanning/2)

In general, the fix is to add an explicit `permissions` block either at the top level of the workflow (to apply to all jobs) or under the specific job (`build_and_deploy`) so that the `GITHUB_TOKEN` used as `repoToken` has the least privileges required. A conservative minimal starting point recommended by CodeQL is `contents: read`. If the Firebase deploy action later proves to need additional scopes (e.g., `deployments: write` or `pull-requests: write`), those can be added explicitly.

For this concrete file, the single best fix without altering existing functionality is to define a `permissions` block at the workflow root, right after the `name:` line and before `on:`. This applies to the single job present and documents the intended permissions. We’ll set:

```yaml
permissions:
  contents: read
```

This limits the `GITHUB_TOKEN` to read-only access to repository contents, which is typically sufficient for actions that only need to read the repo and use other credentials (here, the Firebase service account) for deployment. No imports or additional files are required; it’s a pure YAML configuration change within `.github/workflows/firebase-hosting-merge.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
