### PR TITLE
Harden Firestore rules for board transactions

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -36,6 +36,77 @@ service cloud.firestore {
         ).data.ownerUid == request.auth.uid;
     }
 
+    function allowedTransactionKeys() {
+      return [
+        'name',
+        'cardLast4',
+        'essence',
+        'comment',
+        'amount',
+        'installmentCurrent',
+        'installmentTotal',
+        'type',
+        'transactionDate',
+        'createdByUid',
+        'createdAt',
+      ];
+    }
+
+    function isValidTransactionType(type) {
+      return type in ['credit_card', 'cash', 'standing_order'];
+    }
+
+    function isValidTransactionDate(value) {
+      return value == null
+        || (
+          value is string
+          && value.size() == 10
+          && value.matches('^\\d{4}-\\d{2}-\\d{2}$')
+        );
+    }
+
+    function isValidInstallments(data) {
+      return data.type == 'credit_card'
+        ? (
+            data.cardLast4 is string
+            && data.cardLast4.size() == 4
+            && data.cardLast4.matches('^\\d{4}$')
+            && (
+              (data.installmentCurrent == null && data.installmentTotal == null)
+              || (
+                data.installmentCurrent is int
+                && data.installmentTotal is int
+                && data.installmentCurrent >= 1
+                && data.installmentTotal >= 1
+                && data.installmentCurrent <= data.installmentTotal
+              )
+            )
+          )
+        : (
+            data.cardLast4 == null
+            && data.installmentCurrent == null
+            && data.installmentTotal == null
+          );
+    }
+
+    function isValidTransactionData(data) {
+      return data.keys().hasOnly(allowedTransactionKeys())
+        && data.name is string
+        && data.name.size() > 0
+        && data.name.size() <= 80
+        && data.essence is string
+        && data.essence.size() > 0
+        && data.essence.size() <= 300
+        && (data.comment == null || (data.comment is string && data.comment.size() <= 1000))
+        && data.amount is number
+        && data.amount > 0
+        && data.amount < 100000000
+        && data.type is string
+        && isValidTransactionType(data.type)
+        && isValidTransactionDate(data.transactionDate)
+        && isValidInstallments(data);
+    }
+
     match /boards/{boardId} {
       allow create: if signedIn()
         && request.resource.data.ownerUid == request.auth.uid
@@ -48,7 +119,22 @@ service cloud.firestore {
     }
 
     match /boards/{boardId}/transactions/{transactionId} {
-      allow read, create, update, delete: if isBoardMember(boardId);
+      allow read: if isBoardMember(boardId);
+
+      allow create: if isBoardMember(boardId)
+        && request.resource.data.keys().hasAll(['createdByUid', 'createdAt'])
+        && isValidTransactionData(request.resource.data)
+        && request.resource.data.createdByUid is string
+        && request.resource.data.createdByUid == request.auth.uid
+        && request.resource.data.createdAt is timestamp
+        && request.resource.data.createdAt == request.time;
+
+      allow update: if isBoardMember(boardId)
+        && isValidTransactionData(request.resource.data)
+        && request.resource.data.createdByUid == resource.data.createdByUid
+        && request.resource.data.createdAt == resource.data.createdAt;
+
+      allow delete: if isBoardMember(boardId);
     }
 
     match /boards/{boardId}/invites/{inviteId} {


### PR DESCRIPTION
### Motivation
- Prevent board members from writing arbitrary data into `/boards/{boardId}/transactions/{transactionId}` while preserving existing member read/delete behavior.
- Align server-side validation with the transaction shape used by the frontend and transaction helper functions to protect creator and timestamp metadata.

### Description
- Added transaction validators in `firestore.rules` including a key whitelist (`allowedTransactionKeys()`), type enum check (`isValidTransactionType()`), date-format check (`isValidTransactionDate()`), installment/card consistency (`isValidInstallments()`), and a composed `isValidTransactionData()` predicate enforcing types, lengths, and numeric bounds.
- Restrict `create` to board members and require `createdByUid` to equal `request.auth.uid` and `createdAt` to be a server write (`request.time`), and require the request data to pass `isValidTransactionData()`.
- Restrict `update` to board members and require the updated document to pass `isValidTransactionData()` and preserve `createdByUid` and `createdAt` (immutable after create).
- Preserve `read` and `delete` access for board members (no access widening) and keep the change minimal to match the existing frontend model.

### Testing
- Ran `npm run lint`; the linter failed due to pre-existing unrelated React hook issues in `src/hooks/useBoards.js` and `src/hooks/useIncomingInvites.js` and an existing warning in `src/pages/BoardPage.jsx`, so no rule-emulator tests were executed in this patch.

Notes / Inferred schema and assumptions (summary):
- Inferred transaction fields: `name` (string, required, <=80), `essence` (string, required, <=300), `comment` (string|null, optional, <=1000), `amount` (number, >0, <100000000), `type` (string enum: `credit_card`|`cash`|`standing_order`), `cardLast4` (4-digit string for `credit_card`, null otherwise), `installmentCurrent`/`installmentTotal` (ints >=1 when present, `installmentCurrent <= installmentTotal`), `transactionDate` (`YYYY-MM-DD` string or null), plus history fields `createdByUid` (string) and `createdAt` (timestamp).
- Immutable fields: `createdByUid` and `createdAt` are enforced immutable after creation to prevent forging/changing creator or creation time.
- Blocked malformed/arbitrary writes: unknown keys, wrong types, negative/zero/non-numeric `amount`, invalid `transactionDate` format, credit-card/installment inconsistencies, presence of `cardLast4`/installments for non-credit types, forging/altering `createdByUid` or `createdAt`, and overly long strings.
- Assumptions and minor gaps: string length and amount upper bounds were chosen conservatively to avoid broadening the model; rules validate `transactionDate` format but do not re-implement the frontend calendar or non-future checks (frontend already enforces those). If stricter parity is desired, add calendar/future-date checks to rules.
- Potential cleanup spots: client code already sets `createdByUid` and `createdAt` using `addDoc(..., { createdByUid: uid, createdAt: serverTimestamp() })` and uses `updateDoc` for edits, so no immediate frontend change is required; however, ensure no other backend or functions write transactions with additional keys or with client-supplied `createdAt`/`createdByUid` values that would be rejected by these rules.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd9bf0a82c832a8c0b43c85f4948c3)