### PR TITLE
Refactor TransactionForm layout for better input organization

### DIFF
--- a/src/components/TransactionForm.jsx
+++ b/src/components/TransactionForm.jsx
@@ -183,7 +183,7 @@ export function TransactionForm({ initial, defaultName, defaultPaymentMethod, on
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-4" noValidate>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-        <div className={form.type !== 'credit_card' ? 'sm:col-span-2' : ''}>
+        <div>
           <Input
             label="שם"
             name="name"
@@ -193,40 +193,40 @@ export function TransactionForm({ initial, defaultName, defaultPaymentMethod, on
             error={errors.name}
           />
         </div>
+          <div className="flex flex-col gap-1">
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                סוג עסקה
+            </label>
+            <select
+                name="type"
+                value={form.type}
+                onChange={handleChange}
+                className="block w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-900 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:focus:border-indigo-500 dark:focus:ring-indigo-900"
+            >
+                <option value="">בחר סוג עסקה</option>
+                {Object.entries(TRANSACTION_TYPE_LABELS).map(([value, label]) => (
+                    <option key={value} value={value}>
+                        {label}
+                    </option>
+                ))}
+            </select>
+            {errors.type && (
+                <p className="text-xs text-red-500 mt-0.5" role="alert">{errors.type}</p>
+            )}
+          </div>
+      </div>
         {form.type === 'credit_card' && (
-          <Input
-            label="4 ספרות אחרונות של הכרטיס"
-            name="cardLast4"
-            value={form.cardLast4}
-            onChange={handleChange}
-            placeholder="1234"
-            maxLength={4}
-            inputMode="numeric"
-            error={errors.cardLast4}
-          />
+            <Input
+                label="4 ספרות אחרונות של הכרטיס"
+                name="cardLast4"
+                value={form.cardLast4}
+                onChange={handleChange}
+                placeholder="1234"
+                maxLength={4}
+                inputMode="numeric"
+                error={errors.cardLast4}
+            />
         )}
-      </div>
-      <div className="flex flex-col gap-1">
-        <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
-          סוג עסקה
-        </label>
-        <select
-          name="type"
-          value={form.type}
-          onChange={handleChange}
-          className="block w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-900 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:focus:border-indigo-500 dark:focus:ring-indigo-900"
-        >
-          <option value="">בחר סוג עסקה</option>
-          {Object.entries(TRANSACTION_TYPE_LABELS).map(([value, label]) => (
-            <option key={value} value={value}>
-              {label}
-            </option>
-          ))}
-        </select>
-        {errors.type && (
-          <p className="text-xs text-red-500 mt-0.5" role="alert">{errors.type}</p>
-        )}
-      </div>
       <Input
         label="שם העסק"
         name="essence"

--- a/src/components/TransactionForm.jsx
+++ b/src/components/TransactionForm.jsx
@@ -182,7 +182,7 @@ export function TransactionForm({ initial, defaultName, defaultPaymentMethod, on
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-4" noValidate>
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
         <div>
           <Input
             label="שם"
@@ -194,13 +194,16 @@ export function TransactionForm({ initial, defaultName, defaultPaymentMethod, on
           />
         </div>
           <div className="flex flex-col gap-1">
-            <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+            <label htmlFor="transaction-type" className="text-sm font-medium text-gray-700 dark:text-gray-300">
                 סוג עסקה
             </label>
             <select
+                id="transaction-type"
                 name="type"
                 value={form.type}
                 onChange={handleChange}
+                aria-invalid={errors.type ? 'true' : undefined}
+                aria-describedby={errors.type ? 'transaction-type-error' : undefined}
                 className="block w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-900 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:focus:border-indigo-500 dark:focus:ring-indigo-900"
             >
                 <option value="">בחר סוג עסקה</option>
@@ -211,7 +214,7 @@ export function TransactionForm({ initial, defaultName, defaultPaymentMethod, on
                 ))}
             </select>
             {errors.type && (
-                <p className="text-xs text-red-500 mt-0.5" role="alert">{errors.type}</p>
+                <p id="transaction-type-error" className="text-xs text-red-500 mt-0.5" role="alert">{errors.type}</p>
             )}
           </div>
       </div>


### PR DESCRIPTION
This pull request updates the layout of the `TransactionForm` component to improve the placement of the "last 4 digits of card" input field for credit card transactions. The main change is moving this input outside the grid layout, so it always appears below the transaction type selection, making the form structure clearer and more consistent.

Form layout improvements:

* Moved the "4 ספרות אחרונות של הכרטיס" (`cardLast4`) input field for credit card transactions out of the grid and placed it below the transaction type selection for better form organization. [[1]](diffhunk://#diff-6f8062edbb555216db346cf300ce0292bebf1a35068d388e108729598302cdfdL196-L208) [[2]](diffhunk://#diff-6f8062edbb555216db346cf300ce0292bebf1a35068d388e108729598302cdfdR217-R229)
* Updated the name input field container to always span a single column, simplifying the grid logic.