### PR TITLE
chore(release): bump version to 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 [//]: # (- _No entries yet._)
 
+## [1.1.1]
+
+### Changed
+- Improved the transaction form by placing credit-card-specific fields in a more intuitive location.
+
 ## [1.1.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It supports shared boards, one-level board hierarchies ("super boards" with sub-
 <p align="center">
   <img src="https://img.shields.io/badge/License-MIT-yellow.svg?logo=opensourceinitiative" alt="License: MIT">
   <img src="https://img.shields.io/github/languages/top/OrF8/ExpenseManagement?style=default&logo=javascript&color=F7DF1E" alt="top-language">
-  <img src="https://img.shields.io/badge/Release-v1.1.0-4c1?style=flat" alt="Release v1.1.0">
+  <img src="https://img.shields.io/badge/Release-v1.1.0-4c1?style=flat" alt="Release v1.1.1">
 </p>
 <p align="center">
   <img src="https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=white" alt="react">
@@ -244,7 +244,7 @@ For vulnerability reporting, see [SECURITY.md](./SECURITY.md).
 
 ## Release Status
 
-Current release target: **v1.1.0**.
+Current release target: **v1.1.1**.
 
 Notable release focus:
 - hierarchy-aware collaboration,

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It supports shared boards, one-level board hierarchies ("super boards" with sub-
 <p align="center">
   <img src="https://img.shields.io/badge/License-MIT-yellow.svg?logo=opensourceinitiative" alt="License: MIT">
   <img src="https://img.shields.io/github/languages/top/OrF8/ExpenseManagement?style=default&logo=javascript&color=F7DF1E" alt="top-language">
-  <img src="https://img.shields.io/badge/Release-v1.1.0-4c1?style=flat" alt="Release v1.1.1">
+  <img src="https://img.shields.io/badge/Release-v1.1.1-4c1?style=flat" alt="Release v1.1.1">
 </p>
 <p align="center">
   <img src="https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=white" alt="react">

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "expense-management-functions",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "expense-management-functions",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
         "firebase-admin": "^13.7.0",
         "firebase-functions": "^7.2.3"

--- a/functions/package.json
+++ b/functions/package.json
@@ -22,5 +22,5 @@
     "eslint-config-google": "^0.14.0"
   },
   "private": true,
-  "version": "1.1.0"
+  "version": "1.1.1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "expense-management",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "expense-management",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
         "firebase": "^12.11.0",
         "react": "^19.2.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "expense-management",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
This pull request prepares the project for the v1.1.1 release and introduces a small user experience improvement to the transaction form. The main focus is on updating version numbers and documentation, along with a minor UI enhancement.

Release and documentation updates:

* Updated the version number to `1.1.1` in `package.json`, `functions/package.json`, and `functions/package-lock.json` to reflect the new release. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4) [[2]](diffhunk://#diff-47a4c468f7490979e1df8b5577fd4433613c9c50f054fc38426a0dcddb214436L25-R25) [[3]](diffhunk://#diff-4344b694eb816225873849f96a11303de5fb9cf3b95c349bae6f93df89a426bbL3-R9)
* Updated the release badge, current release target, and related information in the `README.md` to reference v1.1.1 instead of v1.1.0. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L11-R11) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L247-R247)

Changelog and user experience improvements:

* Added a new changelog entry for v1.1.1 in `CHANGELOG.md`, highlighting that credit-card-specific fields in the transaction form have been placed in a more intuitive location.