### PR TITLE
Add password visibility toggle on login form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project are documented in this file.
 
 The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project follows [Semantic Versioning](https://semver.org/).
 
+## [1.1.3]
+
+### Changed
+- Added a password visibility toggle to the login/auth form with eye/eye-off icons so users can show/hide password text on demand.
+- Kept passwords hidden by default whenever the auth form is opened, while preserving existing authentication and validation behavior.
+- Improved input accessibility/id consistency in shared form controls to ensure labels remain correctly linked to their inputs.
+
 ## [1.1.2]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It supports shared boards, one-level board hierarchies ("super boards" with sub-
   <img src="https://img.shields.io/badge/Tailwind_CSS-4-06B6D4?logo=tailwindcss&logoColor=white" alt="tailwind">
 </p>
 <p align="center">
-  <img src="https://github.com/OrF8/ExpenseManagement/actions/workflows/deploy.yml/badge.svg?branch=main" elt="Deploy to Firebase">
+  <img src="https://github.com/OrF8/ExpenseManagement/actions/workflows/deploy.yml/badge.svg?branch=main" alt="Deploy to Firebase">
   <img src="https://github.com/OrF8/ExpenseManagement/actions/workflows/codeql.yml/badge.svg?branch=main" alt="CodeQL Advanced">
 </p>
 

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "expense-management-functions",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "expense-management-functions",
-      "version": "1.1.1",
+      "version": "1.1.3",
       "dependencies": {
         "firebase-admin": "^13.8.0",
         "firebase-functions": "^7.2.5"

--- a/functions/package.json
+++ b/functions/package.json
@@ -22,5 +22,5 @@
     "eslint-config-google": "^0.14.0"
   },
   "private": true,
-  "version": "1.1.2"
+  "version": "1.1.3"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "expense-management",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "expense-management",
-      "version": "1.1.1",
+      "version": "1.1.3",
       "dependencies": {
         "firebase": "^12.11.0",
         "firebase-functions": "^7.2.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "expense-management",
   "private": true,
-  "version": "1.1.2",
+  "version": "1.1.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/ui/Input.jsx
+++ b/src/components/ui/Input.jsx
@@ -1,18 +1,19 @@
 import { useId } from 'react';
 
-export function Input({ label, error, className = '', ...props }) {
-  const id = useId();
-  const errorId = `${id}-error`;
+export function Input({ id: providedId, label, error, className = '', ...props }) {
+    const generatedId = useId();
+    const inputId = providedId ?? generatedId;
+    const errorId = `${inputId}-error`;
 
   return (
     <div className="flex flex-col gap-1">
       {label && (
-        <label htmlFor={id} className="text-sm font-medium text-gray-700 dark:text-gray-300">
+          <label htmlFor={inputId} className="text-sm font-medium text-gray-700 dark:text-gray-300">
           {label}
         </label>
       )}
       <input
-        id={id}
+        id={inputId}
         aria-invalid={error ? 'true' : undefined}
         aria-describedby={error ? errorId : undefined}
         className={`

--- a/src/pages/AuthPage.jsx
+++ b/src/pages/AuthPage.jsx
@@ -201,7 +201,7 @@ export function AuthPage() {
                 onClick={() => setShowPassword((prev) => !prev)}
                 aria-label={showPassword ? 'Hide password' : 'Show password'}
                 aria-pressed={showPassword}
-                className="absolute inset-y-0 left-1 inline-flex h-10 w-10 items-center justify-center rounded-md text-gray-500 transition-colors hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:text-gray-400 dark:hover:text-gray-200 dark:focus:ring-indigo-900"
+                className="absolute left-1 bottom-0 inline-flex h-10 w-10 items-center justify-center rounded-md text-gray-500 transition-colors hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:text-gray-400 dark:hover:text-gray-200 dark:focus:ring-indigo-900"
               >
                 {showPassword ? (
                   <svg

--- a/src/pages/AuthPage.jsx
+++ b/src/pages/AuthPage.jsx
@@ -212,7 +212,7 @@ export function AuthPage() {
                   onClick={() => setShowPassword((prev) => !prev)}
                   aria-label={showPassword ? 'הסתר סיסמה' : 'הצג סיסמה'}
                   aria-pressed={showPassword}
-                  className="absolute inset-y-0 left-1 inline-flex h-10 w-10 items-center justify-center rounded-md text-gray-500 transition-colors hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:text-gray-400 dark:hover:text-gray-200 dark:focus:ring-indigo-900"
+                  className="absolute inset-y-0 end-1 inline-flex h-10 w-10 items-center justify-center rounded-md text-gray-500 transition-colors hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:text-gray-400 dark:hover:text-gray-200 dark:focus:ring-indigo-900"
                 >
                   {showPassword ? (
                     <svg

--- a/src/pages/AuthPage.jsx
+++ b/src/pages/AuthPage.jsx
@@ -120,7 +120,7 @@ export function AuthPage() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-50 via-white to-indigo-50 dark:from-gray-950 dark:via-gray-900 dark:to-slate-900 px-4">
+    <div className="min-h-screen flex items-center justify-center bg-linear-to-br from-slate-50 via-white to-indigo-50 dark:from-gray-950 dark:via-gray-900 dark:to-slate-900 px-4">
       <div className="w-full max-w-sm">
         <div className="mb-8 text-center">
           <img
@@ -237,7 +237,6 @@ export function AuthPage() {
                     </svg>
                   )}
                 </button>
-              </div>
             </div>
             {tab === 'signin' && (
               <div className="flex justify-start">

--- a/src/pages/AuthPage.jsx
+++ b/src/pages/AuthPage.jsx
@@ -210,7 +210,7 @@ export function AuthPage() {
                 <button
                   type="button"
                   onClick={() => setShowPassword((prev) => !prev)}
-                  aria-label={showPassword ? 'Hide password' : 'Show password'}
+                  aria-label={showPassword ? 'הסתר סיסמה' : 'הצג סיסמה'}
                   aria-pressed={showPassword}
                   className="absolute inset-y-0 left-1 inline-flex h-10 w-10 items-center justify-center rounded-md text-gray-500 transition-colors hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:text-gray-400 dark:hover:text-gray-200 dark:focus:ring-indigo-900"
                 >

--- a/src/pages/AuthPage.jsx
+++ b/src/pages/AuthPage.jsx
@@ -184,48 +184,37 @@ export function AuthPage() {
                 required
               />
             )}
-            <div className="flex flex-col gap-1">
-              <label htmlFor={passwordInputId} className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                סיסמה
-              </label>
-              <div className="relative">
-                <input
-                  id={passwordInputId}
-                  type={showPassword ? 'text' : 'password'}
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  placeholder="••••••••"
-                  autoComplete={tab === 'signin' ? 'current-password' : 'new-password'}
-                  className="
-                    block w-full rounded-lg border border-gray-200 bg-white
-                    px-3 py-2 pl-11 text-sm text-gray-900 placeholder:text-gray-400
-                    focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200
-                    disabled:bg-gray-50 disabled:text-gray-500
-                    dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:placeholder:text-gray-500
-                    dark:focus:border-indigo-500 dark:focus:ring-indigo-900
-                    dark:disabled:bg-gray-900 dark:disabled:text-gray-600
-                  "
-                  required
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowPassword((prev) => !prev)}
-                  aria-label={showPassword ? 'הסתר סיסמה' : 'הצג סיסמה'}
-                  aria-pressed={showPassword}
-                  className="absolute inset-y-0 end-1 inline-flex h-10 w-10 items-center justify-center rounded-md text-gray-500 transition-colors hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:text-gray-400 dark:hover:text-gray-200 dark:focus:ring-indigo-900"
-                >
-                  {showPassword ? (
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      className="h-5 w-5"
-                      aria-hidden="true"
-                    >
+            <div className="relative">
+              <Input
+                id={passwordInputId}
+                label="סיסמה"
+                type={showPassword ? 'text' : 'password'}
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="••••••••"
+                autoComplete={tab === 'signin' ? 'current-password' : 'new-password'}
+                className="pl-11"
+                required
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword((prev) => !prev)}
+                aria-label={showPassword ? 'Hide password' : 'Show password'}
+                aria-pressed={showPassword}
+                className="absolute inset-y-0 left-1 inline-flex h-10 w-10 items-center justify-center rounded-md text-gray-500 transition-colors hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:text-gray-400 dark:hover:text-gray-200 dark:focus:ring-indigo-900"
+              >
+                {showPassword ? (
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    className="h-5 w-5"
+                    aria-hidden="true"
+                  >
                       <path d="M10.58 10.58a2 2 0 1 0 2.83 2.83" />
                       <path d="M9.88 4.24A10.94 10.94 0 0 1 12 4c7 0 10 8 10 8a17.6 17.6 0 0 1-2.17 3.19" />
                       <path d="M6.61 6.61A17.36 17.36 0 0 0 2 12s3 8 10 8a9.74 9.74 0 0 0 5.39-1.61" />

--- a/src/pages/AuthPage.jsx
+++ b/src/pages/AuthPage.jsx
@@ -1,7 +1,7 @@
 /**
  * Authentication page with sign-in and sign-up tabs.
  */
-import { useState } from 'react';
+import { useId, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { signIn, signUp, signInWithGoogle, resetPassword } from '../firebase/auth';
 import { Input } from '../components/ui/Input';
@@ -33,9 +33,11 @@ function getHebrewResetError(code) {
 }
 
 export function AuthPage() {
+  const passwordInputId = useId();
   const [tab, setTab] = useState('signin');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
   const [nickname, setNickname] = useState('');
   const [loading, setLoading] = useState(false);
   const [googleLoading, setGoogleLoading] = useState(false);
@@ -138,7 +140,12 @@ export function AuthPage() {
             ].map((t) => (
               <button
                 key={t.id}
-                onClick={() => { setTab(t.id); setError(null); setNickname(''); }}
+                onClick={() => {
+                  setTab(t.id);
+                  setError(null);
+                  setNickname('');
+                  setShowPassword(false);
+                }}
                 className={`flex-1 py-2 px-3 rounded-lg text-sm font-medium transition-all ${
                   tab === t.id
                     ? 'bg-white dark:bg-gray-700 text-indigo-600 dark:text-indigo-400 shadow-sm'
@@ -177,15 +184,72 @@ export function AuthPage() {
                 required
               />
             )}
-            <Input
-              label="סיסמה"
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              placeholder="••••••••"
-              autoComplete={tab === 'signin' ? 'current-password' : 'new-password'}
-              required
-            />
+            <div className="flex flex-col gap-1">
+              <label htmlFor={passwordInputId} className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                סיסמה
+              </label>
+              <div className="relative">
+                <input
+                  id={passwordInputId}
+                  type={showPassword ? 'text' : 'password'}
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="••••••••"
+                  autoComplete={tab === 'signin' ? 'current-password' : 'new-password'}
+                  className="
+                    block w-full rounded-lg border border-gray-200 bg-white
+                    px-3 py-2 pl-11 text-sm text-gray-900 placeholder:text-gray-400
+                    focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200
+                    disabled:bg-gray-50 disabled:text-gray-500
+                    dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:placeholder:text-gray-500
+                    dark:focus:border-indigo-500 dark:focus:ring-indigo-900
+                    dark:disabled:bg-gray-900 dark:disabled:text-gray-600
+                  "
+                  required
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword((prev) => !prev)}
+                  aria-label={showPassword ? 'Hide password' : 'Show password'}
+                  aria-pressed={showPassword}
+                  className="absolute inset-y-0 left-1 inline-flex h-10 w-10 items-center justify-center rounded-md text-gray-500 transition-colors hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:text-gray-400 dark:hover:text-gray-200 dark:focus:ring-indigo-900"
+                >
+                  {showPassword ? (
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      className="h-5 w-5"
+                      aria-hidden="true"
+                    >
+                      <path d="M10.58 10.58a2 2 0 1 0 2.83 2.83" />
+                      <path d="M9.88 4.24A10.94 10.94 0 0 1 12 4c7 0 10 8 10 8a17.6 17.6 0 0 1-2.17 3.19" />
+                      <path d="M6.61 6.61A17.36 17.36 0 0 0 2 12s3 8 10 8a9.74 9.74 0 0 0 5.39-1.61" />
+                      <line x1="2" x2="22" y1="2" y2="22" />
+                    </svg>
+                  ) : (
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      className="h-5 w-5"
+                      aria-hidden="true"
+                    >
+                      <path d="M2.06 12S5.03 4 12 4s9.94 8 9.94 8-2.97 8-9.94 8-9.94-8-9.94-8Z" />
+                      <circle cx="12" cy="12" r="3" />
+                    </svg>
+                  )}
+                </button>
+              </div>
+            </div>
             {tab === 'signin' && (
               <div className="flex justify-start">
                 <button


### PR DESCRIPTION
### Motivation

- Improve usability on the login/signup form by letting users reveal their password briefly to verify input while keeping default behavior unchanged.

### Description

- Added local state `showPassword` in `AuthPage` and bound the password input `type` to `showPassword` so it toggles between `"password"` and `"text"`.
- Replaced the password field rendering with a relative container that includes an inline toggle `button` using inline SVG eye / eye-off icons so no new dependency was introduced.
- Made the toggle accessible with `type="button"`, dynamic `aria-label`, `aria-pressed`, a 40x40 hit area for touch, and added left padding to the input to avoid text overlap while respecting the app RTL layout.
- Kept authentication and validation logic unchanged and reset `showPassword` to `false` when switching tabs so visibility is hidden by default each time the form opens.

### Testing

- `npm run build` completed successfully.
- `npm run lint` failed due to unrelated pre-existing lint errors in `src/components/CollaboratorManager.jsx` and `src/pages/BoardPage.jsx`, not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ece240705c832a9732c4f28cb05885)