### PR TITLE
Add secure "Move transaction" callable and UI to transfer transactions between boards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [1.1.4]
 
+## [Unreleased]
+
+### Added
+- Added the ability to move transactions between boards the user has access to.
+
 ### Changed
 - Updated backend dependency `fast-xml-builder` to `1.2.0` to address a security vulnerabilities (CVE-2026-44665, CVE-2026-44665) in versions prior to `1.1.7`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,13 @@ All notable changes to this project are documented in this file.
 
 The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project follows [Semantic Versioning](https://semver.org/).
 
-## [1.1.4]
-
-## [Unreleased]
+## [1.2.0]
 
 ### Added
+
 - Added the ability to move transactions between boards the user has access to.
+
+## [1.1.4]
 
 ### Changed
 - Updated backend dependency `fast-xml-builder` to `1.2.0` to address a security vulnerabilities (CVE-2026-44665, CVE-2026-44665) in versions prior to `1.1.7`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,12 +5,13 @@
 Security fixes are provided for the latest minor line only.
 
 | Version | Supported |
-| --- | --- |
-| 1.1.x | ✅ |
-| 1.0.x | ❌ |
+|---------| -- |
+| 1.2.x   | ✅ |
+| 1.1.x   | ❌ |
+| 1.0.x   | ❌ |
 | < 1.0.0 | ❌ |
 
-If you run a self-hosted deployment, upgrade to the latest `1.1.x` patch release as soon as practical.
+If you run a self-hosted deployment, upgrade to the latest `1.2.x` patch release as soon as practical.
 
 ## Reporting a Vulnerability
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -53,6 +53,11 @@ admin.initializeApp();
 
 const db = admin.firestore();
 
+function userHasBoardAccess(boardData, uid) {
+  const memberUids = Array.isArray(boardData?.memberUids) ? boardData.memberUids : [];
+  return memberUids.includes(uid);
+}
+
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
@@ -503,6 +508,78 @@ exports.declineBoardInvite = onCall(
 
       return {success: true};
     }
+);
+
+/**
+ * moveTransaction
+ *
+ * Moves a single transaction document from one board to another in a single
+ * Firestore transaction. Preserves the original transaction ID and data.
+ */
+exports.moveTransaction = onCall(
+    {enforceAppCheck: true},
+    async (request) => {
+      if (!request.auth) {
+        throw new HttpsError('unauthenticated', 'עליך להתחבר כדי להעביר עסקה');
+      }
+
+      const uid = request.auth.uid;
+      const {sourceBoardId, destinationBoardId, transactionId} = request.data || {};
+      if (
+        typeof sourceBoardId !== 'string' || !sourceBoardId.trim() ||
+        typeof destinationBoardId !== 'string' || !destinationBoardId.trim() ||
+        typeof transactionId !== 'string' || !transactionId.trim()
+      ) {
+        throw new HttpsError('invalid-argument', 'sourceBoardId, destinationBoardId ו-transactionId נדרשים');
+      }
+
+      if (sourceBoardId === destinationBoardId) {
+        throw new HttpsError('failed-precondition', 'לא ניתן להעביר עסקה לאותו לוח');
+      }
+
+      const sourceBoardRef = db.collection('boards').doc(sourceBoardId);
+      const destinationBoardRef = db.collection('boards').doc(destinationBoardId);
+      const sourceTxRef = sourceBoardRef.collection('transactions').doc(transactionId);
+      const destinationTxRef = destinationBoardRef.collection('transactions').doc(transactionId);
+
+      await db.runTransaction(async (tx) => {
+        const [sourceBoardSnap, destinationBoardSnap, sourceTxSnap, destinationTxSnap] = await Promise.all([
+          tx.get(sourceBoardRef),
+          tx.get(destinationBoardRef),
+          tx.get(sourceTxRef),
+          tx.get(destinationTxRef),
+        ]);
+
+        if (!sourceBoardSnap.exists) throw new HttpsError('not-found', 'לוח המקור לא נמצא');
+        if (!destinationBoardSnap.exists) throw new HttpsError('not-found', 'לוח היעד לא נמצא');
+
+        if (!userHasBoardAccess(sourceBoardSnap.data(), uid) || !userHasBoardAccess(destinationBoardSnap.data(), uid)) {
+          throw new HttpsError('permission-denied', 'אין לך הרשאה להעביר עסקה לאחד הלוחות שנבחרו');
+        }
+
+        if (!sourceTxSnap.exists) {
+          throw new HttpsError('not-found', 'העסקה לא נמצאה. ייתכן שהיא נמחקה או הועברה כבר');
+        }
+
+        if (destinationTxSnap.exists) {
+          throw new HttpsError('already-exists', 'כבר קיימת עסקה עם אותו מזהה בלוח היעד');
+        }
+
+        const transactionData = sourceTxSnap.data();
+        tx.set(destinationTxRef, {
+          ...transactionData,
+          updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+        });
+        tx.delete(sourceTxRef);
+      });
+
+      return {
+        success: true,
+        sourceBoardId,
+        destinationBoardId,
+        transactionId,
+      };
+    },
 );
 
 /**

--- a/functions/index.js
+++ b/functions/index.js
@@ -553,7 +553,19 @@ exports.moveTransaction = onCall(
         if (!sourceBoardSnap.exists) throw new HttpsError('not-found', 'לוח המקור לא נמצא');
         if (!destinationBoardSnap.exists) throw new HttpsError('not-found', 'לוח היעד לא נמצא');
 
-        if (!userHasBoardAccess(sourceBoardSnap.data(), uid) || !userHasBoardAccess(destinationBoardSnap.data(), uid)) {
+        const sourceBoard = sourceBoardSnap.data();
+        const destinationBoard = destinationBoardSnap.data();
+        const isSuperBoard = (board) => Array.isArray(board && board.subBoardIds);
+
+        if (isSuperBoard(sourceBoard)) {
+          throw new HttpsError('failed-precondition', 'לא ניתן להעביר עסקה מלוח-על');
+        }
+
+        if (isSuperBoard(destinationBoard)) {
+          throw new HttpsError('failed-precondition', 'לא ניתן להעביר עסקה ללוח-על');
+        }
+
+        if (!userHasBoardAccess(sourceBoard, uid) || !userHasBoardAccess(destinationBoard, uid)) {
           throw new HttpsError('permission-denied', 'אין לך הרשאה להעביר עסקה לאחד הלוחות שנבחרו');
         }
 

--- a/functions/package.json
+++ b/functions/package.json
@@ -22,5 +22,5 @@
     "eslint-config-google": "^0.14.0"
   },
   "private": true,
-  "version": "1.1.4"
+  "version": "1.2.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "expense-management",
   "private": true,
-  "version": "1.1.4",
+  "version": "1.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/TransactionCard.jsx
+++ b/src/components/TransactionCard.jsx
@@ -25,7 +25,7 @@ function formatTransactionDate(dateStr) {
   return `${String(day).padStart(2, '0')}/${String(month).padStart(2, '0')}/${year}`;
 }
 
-export function TransactionCard({ transaction, onEdit, onDelete }) {
+export function TransactionCard({ transaction, onEdit, onDelete, onMove }) {
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState(null);
 
@@ -86,6 +86,17 @@ export function TransactionCard({ transaction, onEdit, onDelete }) {
             {formatAmount(transaction.amount)}
           </span>
           <div className="flex gap-1">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => onMove(transaction)}
+              title="העבר עסקה"
+              aria-label="העבר עסקה"
+            >
+              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 7h11m0 0l-3-3m3 3l-3 3M20 17H9m0 0l3-3m-3 3l3 3" />
+              </svg>
+            </Button>
             <Button
               variant="ghost"
               size="sm"

--- a/src/firebase/transactions.js
+++ b/src/firebase/transactions.js
@@ -14,7 +14,8 @@ import {
   orderBy,
   serverTimestamp,
 } from 'firebase/firestore';
-import { db } from './config';
+import { httpsCallable } from 'firebase/functions';
+import { db, functions } from './config';
 
 const txRef = (boardId) =>
   collection(db, 'boards', boardId, 'transactions');
@@ -91,4 +92,23 @@ export async function getBoardTotal(boardId) {
     total += Number(d.data().amount) || 0;
   });
   return total;
+}
+
+/**
+ * Move transaction between boards via secure callable function.
+ */
+export async function moveTransaction(sourceBoardId, destinationBoardId, transactionId) {
+  const fn = httpsCallable(functions, 'moveTransaction');
+  try {
+    const result = await fn({ sourceBoardId, destinationBoardId, transactionId });
+    return result.data;
+  } catch (err) {
+    const code = err?.code || '';
+    if (code === 'functions/unauthenticated') throw new Error('עליך להתחבר מחדש כדי להעביר עסקה.');
+    if (code === 'functions/permission-denied') throw new Error('אין לך הרשאה להעביר עסקה לאחד הלוחות שנבחרו.');
+    if (code === 'functions/not-found') throw new Error(err?.message || 'העסקה לא נמצאה. ייתכן שהיא נמחקה או הועברה כבר.');
+    if (code === 'functions/already-exists') throw new Error('כבר קיימת עסקה עם אותו מזהה בלוח היעד.');
+    if (code === 'functions/failed-precondition') throw new Error(err?.message || 'לא ניתן להעביר את העסקה.');
+    throw new Error('אירעה שגיאה בעת העברת העסקה. נסה שוב.');
+  }
 }

--- a/src/pages/BoardPage.jsx
+++ b/src/pages/BoardPage.jsx
@@ -12,7 +12,7 @@ import { useTransactions } from '../hooks/useTransactions';
 import { useBoards } from '../hooks/useBoards';
 import { useBoardTotals } from '../hooks/useBoardTotals';
 import { useAuth } from '../context/AuthContext';
-import { addTransaction, updateTransaction, deleteTransaction, getTransactionsForBoard } from '../firebase/transactions';
+import { addTransaction, updateTransaction, deleteTransaction, getTransactionsForBoard, moveTransaction } from '../firebase/transactions';
 import { subscribeToBoard, removeSubBoardFromSuper, mergeBoardsIntoSuper, createBoard, renameBoard } from '../firebase/boards';
 import { getUserProfile } from '../firebase/users';
 import { isMergeValid } from '../utils/boardHierarchy';
@@ -51,6 +51,7 @@ export function BoardPage() {
   const [submitting, setSubmitting] = useState(false);
   const [exportingExcel, setExportingExcel] = useState(false);
   const [exportError, setExportError] = useState(null);
+  const [moveSuccessMessage, setMoveSuccessMessage] = useState(null);
   const [userNickname, setUserNickname] = useState('');
   /**
    * Active payment-method filter.
@@ -386,6 +387,39 @@ export function BoardPage() {
     await deleteTransaction(boardId, txId);
   }
 
+  const [moveTx, setMoveTx] = useState(null);
+  const [moveDestinationBoardId, setMoveDestinationBoardId] = useState('');
+  const [movingTransaction, setMovingTransaction] = useState(false);
+  const [moveTransactionError, setMoveTransactionError] = useState(null);
+
+  const destinationBoards = useMemo(
+    () => allBoards.filter((candidate) => candidate.id !== boardId),
+    [allBoards, boardId],
+  );
+
+  function openMoveModal(transaction) {
+    setMoveTx(transaction);
+    setMoveDestinationBoardId('');
+    setMoveTransactionError(null);
+  }
+
+  async function handleMoveTransaction() {
+    if (!moveTx || !moveDestinationBoardId) return;
+    setMovingTransaction(true);
+    setMoveTransactionError(null);
+    try {
+      await moveTransaction(boardId, moveDestinationBoardId, moveTx.id);
+      setMoveTx(null);
+      setMoveDestinationBoardId('');
+      setMoveSuccessMessage('העסקה הועברה בהצלחה.');
+      window.setTimeout(() => setMoveSuccessMessage(null), 3000);
+    } catch (err) {
+      setMoveTransactionError(err.message || 'אירעה שגיאה בעת העברת העסקה. נסה שוב.');
+    } finally {
+      setMovingTransaction(false);
+    }
+  }
+
   async function handleExportExcel() {
     if (!board) return;
     setExportingExcel(true);
@@ -545,6 +579,11 @@ export function BoardPage() {
         {exportError && (
           <div className="rounded-xl bg-red-50 dark:bg-red-900/30 border border-red-100 dark:border-red-800 px-4 py-3 text-sm text-red-600 dark:text-red-400">
             {exportError}
+          </div>
+        )}
+        {moveSuccessMessage && (
+          <div className="rounded-xl bg-emerald-50 dark:bg-emerald-900/30 border border-emerald-100 dark:border-emerald-800 px-4 py-3 text-sm text-emerald-700 dark:text-emerald-400">
+            {moveSuccessMessage}
           </div>
         )}
         {isSuperBoard ? (
@@ -718,6 +757,7 @@ export function BoardPage() {
                     <TransactionCard
                       key={tx.id}
                       transaction={tx}
+                      onMove={openMoveModal}
                       onEdit={(tx) => setEditTx(tx)}
                       onDelete={handleDelete}
                     />
@@ -756,6 +796,45 @@ export function BoardPage() {
           onCancel={() => setEditTx(null)}
           submitting={submitting}
         />
+      </Modal>
+
+      <Modal
+        isOpen={!!moveTx}
+        onClose={() => !movingTransaction && setMoveTx(null)}
+        title="העברת עסקה"
+      >
+        <div className="space-y-4">
+          <p className="text-sm text-gray-600 dark:text-gray-300">בחר לוח יעד שאליו העסקה תועבר.</p>
+          {destinationBoards.length === 0 ? (
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              אין לוחות אחרים שניתן להעביר אליהם את העסקה.
+            </p>
+          ) : (
+            <label className="block space-y-2">
+              <span className="text-sm text-gray-700 dark:text-gray-200">בחר לוח יעד</span>
+              <select
+                className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm dark:bg-gray-800 dark:border-gray-700"
+                value={moveDestinationBoardId}
+                onChange={(e) => setMoveDestinationBoardId(e.target.value)}
+                disabled={movingTransaction}
+              >
+                <option value="">בחר...</option>
+                {destinationBoards.map((candidate) => (
+                  <option key={candidate.id} value={candidate.id}>{candidate.title}</option>
+                ))}
+              </select>
+            </label>
+          )}
+          {moveTransactionError && (
+            <p className="text-sm text-red-500 dark:text-red-400" role="alert">{moveTransactionError}</p>
+          )}
+          <div className="flex justify-end gap-2">
+            <Button variant="secondary" onClick={() => setMoveTx(null)} disabled={movingTransaction}>ביטול</Button>
+            <Button onClick={handleMoveTransaction} loading={movingTransaction} disabled={!moveDestinationBoardId || destinationBoards.length === 0}>
+              {movingTransaction ? 'מעביר...' : 'העבר'}
+            </Button>
+          </div>
+        </div>
       </Modal>
 
       {/* Collaborators Modal */}


### PR DESCRIPTION
### Motivation
- Enable moving a transaction from one board to another while enforcing server-side authorization and preserving data integrity.
- Avoid client-only permission checks by performing the move atomically with the Admin SDK in a callable Cloud Function.

### Description
- Added `moveTransaction` callable Cloud Function in `functions/index.js` that validates authentication, input types, source/destination existence, effective membership access, source transaction existence, same-board prevention, and destination-ID collision, then performs an atomic copy+delete in a Firestore transaction while preserving the original transaction ID. 
- Added a small helper `userHasBoardAccess` in `functions/index.js` and used it for access checks inside `moveTransaction`.
- Added a client wrapper `moveTransaction(sourceBoardId, destinationBoardId, transactionId)` in `src/firebase/transactions.js` that calls the callable and maps common function error codes to Hebrew user-facing messages.
- Updated UI: added a `העבר עסקה` ghost action button to `TransactionCard` and wired a move flow into `BoardPage` including a `העברת עסקה` modal, destination board selector excluding the current board, empty-state messaging, loading/error states, and a success banner; the modal invokes the client wrapper to perform the move.
- Updated `CHANGELOG.md` with an unreleased entry for the new feature.

### Testing
- Ran frontend lint via `npm run lint`; the command failed due to existing React Hooks lint issues in files outside the introduced changes, so lint did not pass end-to-end for the repository.
- No additional automated unit/integration tests were added for the callable function or UI in this change set (callable behavior should be covered by server-side function tests in a follow-up).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a020c655c40832a8fc63d0a2be8082b)