### PR TITLE
Fix protobufjs Dependabot security alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5491,22 +5491,22 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
+      "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/codegen": "^2.0.5",
         "@protobufjs/eventemitter": "^1.1.0",
         "@protobufjs/fetch": "^1.1.0",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/inquire": "^1.1.1",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
         "long": "^5.0.0"
       },


### PR DESCRIPTION
### Motivation
- Dependabot reported 7 alerts for `protobufjs` (<= 7.5.5); the goal is to ensure all resolved `protobufjs` versions are >= `7.5.6` without adding unnecessary direct dependencies.
- The repository contains two npm projects (root and `functions/`), and `protobufjs` is pulled in transitively via `firebase` / `firebase-functions` / `firebase-admin`.

### Description
- Updated the root `package-lock.json` entry for `node_modules/protobufjs` from `7.5.5` to `7.5.8`, including the `resolved` tarball URL, `integrity` hash, and the bumped subdependency ranges (`@protobufjs/codegen`, `@protobufjs/inquire`, `@protobufjs/utf8`).
- Did not add `protobufjs` to `dependencies` or add an `overrides` section; `functions/` already resolves `protobufjs@7.5.8`, so the change keeps dependency intent minimal and lockfile-only.
- Changed file: `package-lock.json` (root); no `package.json` or `functions/package.json` edits were required.

### Testing
- Ran `npm ls protobufjs` in `functions/` and saw all resolved versions at `7.5.8`.
- Attempted `npm update protobufjs` and `npm audit` in this environment but both failed due to registry access policy (`403 Forbidden`), so a fully-verified install/audit could not be performed here.
- Ran project checks: `npm run build` (root) succeeded, `npm run lint` (root) failed on pre-existing React Hooks lint errors unrelated to the lockfile change, and `npm run lint` (functions) is configured to skip linting.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a045b3ec2b4832a9556d5f212cdbbfc)