### PR TITLE
Fix js-yaml dependency issue

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "expense-management-functions",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "expense-management-functions",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "dependencies": {
         "firebase-admin": "^13.9.0",
         "firebase-functions": "^7.2.5"

--- a/functions/package.json
+++ b/functions/package.json
@@ -24,6 +24,7 @@
     "eslint-config-google": "^0.14.0"
   },
   "overrides": {
-  "protobufjs": "7.6.3"
+    "protobufjs": "7.6.3",
+    "js-yaml": "4.2.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "expense-management",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "expense-management",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "dependencies": {
         "firebase": "^12.11.0",
         "react": "^19.2.4",
@@ -2912,10 +2912,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -30,8 +30,9 @@
     "vite": "^8.0.16"
   },
   "overrides": {
-  "@babel/core": "7.29.6",
-  "form-data": "2.5.6",
-  "protobufjs": "7.6.3"
+    "@babel/core": "7.29.6",
+    "form-data": "2.5.6",
+    "protobufjs": "7.6.3",
+    "js-yaml": "4.2.0"
   }
 }


### PR DESCRIPTION
This pull request updates dependency overrides in both the root and functions packages to address security or compatibility concerns, and bumps the version of the `expense-management-functions` package.

Dependency management updates:

* Added an override for the `js-yaml` dependency, pinning it to version `4.2.0` in both the root `package.json` and `functions/package.json` to ensure consistent and secure usage across the project. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L35-R36) [[2]](diffhunk://#diff-47a4c468f7490979e1df8b5577fd4433613c9c50f054fc38426a0dcddb214436L27-R28)

Version update:

* Bumped the version of the `expense-management-functions` package from `1.2.1` to `1.2.2` in both `package.json` and `package-lock.json` to reflect the dependency changes.