### PR TITLE
Add transaction duplication flow (cloud function + UI)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,11 +46,6 @@ jobs:
       - name: Install functions dependencies
         run: npm --prefix functions ci
 
-      - name: Deploy firestore rules
-        run: firebase deploy --only firestore:rules --project "$FIREBASE_PROJECT_ID"
-        env:
-          FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
-
       - name: Build frontend
         run: npm run build
         env:
@@ -65,7 +60,7 @@ jobs:
       - name: Install Firebase CLI
         run: npm install -g firebase-tools
 
-      - name: Deploy Functions and Hosting
-        run: firebase deploy --only functions,hosting --project "$FIREBASE_PROJECT_ID"
+      - name: Deploy Functions, Firestore rules and Hosting
+        run: firebase deploy --only functions,firestore:rules,hosting --project "$FIREBASE_PROJECT_ID"
         env:
           FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,6 +46,11 @@ jobs:
       - name: Install functions dependencies
         run: npm --prefix functions ci
 
+      - name: Deploy firestore rules
+        run: firebase deploy --only firestore:rules --project "$FIREBASE_PROJECT_ID"
+        env:
+          FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
+
       - name: Build frontend
         run: npm run build
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,38 @@ All notable changes to this project are documented in this file.
 
 The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project follows [Semantic Versioning](https://semver.org/).
 
-## [1.2.1]
+## [1.3.0]
 
-### Unreleased
-- Minor `Dependabot` security fixes.
+### Added
+
+- Added the ability to duplicate a transaction to another regular board while keeping the original transaction unchanged.
+- Added a dedicated duplicate transaction action, destination-board selection modal, Hebrew success/error messages, and secure server-side duplication through a Firebase Callable Function.
+- Added duplication metadata for copied transactions, including the source board, source transaction, duplicating user, and duplication timestamp.
 
 ### Changed
+
+- Updated deployment flows to deploy Firestore rules together with Firebase Functions and Hosting, ensuring rule changes are applied when backend or schema behavior changes.
+
+### Fixed
+
+- Updated Firestore transaction rules so duplicated transactions remain editable while preserving immutable creation and duplication metadata.
+- Added server-side validation to prevent duplicating transactions to the same board.
+- Added server-side validation to prevent duplicating transactions from or to super-boards.
+
+### Security
+
+- Security policy updated to supported-version policy for `1.3.x`.
+
+## [1.2.2]
+
+### Security
+
+- Dependabot security updates.
+
+## [1.2.1]
+
+### Changed
+
 - Updated backend dependency `protobufjs` to `7.5.8` to address a security vulnerability (CVE-2026-44292) in versions prior to `7.5.5`.
 - Refreshed frontend lockfile dependencies to current compatible versions for improved maintenance and stability.
 - Minor optimizations and cleanup in all the code.
@@ -24,11 +50,13 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 ## [1.1.4]
 
 ### Changed
+
 - Updated backend dependency `fast-xml-builder` to `1.2.0` to address a security vulnerabilities (CVE-2026-44665, CVE-2026-44665) in versions prior to `1.1.7`.
 
 ## [1.1.3]
 
 ### Changed
+
 - Added a password visibility toggle to the login/auth form with eye/eye-off icons so users can show/hide password text on demand.
 - Kept passwords hidden by default whenever the auth form is opened, while preserving existing authentication and validation behavior.
 - Improved input accessibility/id consistency in shared form controls to ensure labels remain correctly linked to their inputs.
@@ -36,20 +64,24 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 ## [1.1.2]
 
 ### Changed
+
 - Updated backend dependencies, including `firebase-admin` to `13.8.0`, plus related lockfile updates.
 - Refreshed frontend lockfile dependencies to current compatible versions for improved maintenance and stability.
 
 ### Security
+
 - Pulled in transitive dependency updates that address Dependabot-reported vulnerabilities (including `node-forge` via `firebase-admin`).
 
 ## [1.1.1]
 
 ### Changed
+
 - Improved the transaction form by placing credit-card-specific fields in a more intuitive location.
 
 ## [1.1.0]
 
 ### Added
+
 - Excel export for boards using `.xlsx` output.
 - Super-board export support with multiple worksheets (one worksheet per sub-board).
 - Optional summary worksheet in super-board exports.
@@ -57,28 +89,34 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 - Explicit direct vs. inherited collaborator display in board collaboration management.
 
 ### Changed
+
 - Documentation refresh across README, security policy, and release notes for the `v1.1.0` release.
 - Version alignment across frontend and Cloud Functions packages to `1.1.0`.
 
 ### Fixed
+
 - Export date handling and workbook formatting improvements in generated Excel files.
 - Export-related CSP allowance updates for ExcelJS-hosted assets.
 - Board/super-board export UI flow improvements and related stability fixes.
 
 ### Security
+
 - Security policy updated to supported-version policy for `1.1.x` and private reporting guidance.
 
 ## [1.0.4]
 
 ### Changed
+
 - Dependency and maintenance updates before `1.1.0`.
 
 ## [1.0.1]
 
 ### Changed
+
 - Early post-`1.0.0` maintenance updates.
 
 ## [1.0.0]
 
 ### Added
+
 - Initial public release of the Expense Management application.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,8 @@ Security fixes are provided for the latest minor line only.
 
 | Version | Supported |
 |---------|:---------:|
-| 1.2.x   |    ✅     |
+| 1.3.x   |    ✅     |
+| 1.2.x   |    ❌     |
 | 1.1.x   |     ❌    |
 | 1.0.x   |     ❌    |
 | < 1.0.0 |     ❌    |

--- a/firestore.rules
+++ b/firestore.rules
@@ -36,6 +36,31 @@ service cloud.firestore {
         ).data.ownerUid == request.auth.uid;
     }
 
+    function baseTransactionKeys() {
+      return [
+        'name',
+        'cardLast4',
+        'essence',
+        'comment',
+        'amount',
+        'installmentCurrent',
+        'installmentTotal',
+        'type',
+        'transactionDate',
+        'createdByUid',
+        'createdAt',
+      ];
+    }
+
+    function transactionMetadataKeys() {
+      return [
+        'updatedAt',
+        'duplicatedFrom',
+        'duplicatedByUid',
+        'duplicatedAt',
+      ];
+    }
+
     function allowedTransactionKeys() {
       return [
         'name',
@@ -49,6 +74,10 @@ service cloud.firestore {
         'transactionDate',
         'createdByUid',
         'createdAt',
+        'updatedAt',
+        'duplicatedFrom',
+        'duplicatedByUid',
+        'duplicatedAt',
       ];
     }
 
@@ -89,9 +118,8 @@ service cloud.firestore {
           );
     }
 
-    function isValidTransactionData(data) {
-      return data.keys().hasOnly(allowedTransactionKeys())
-        && data.name is string
+    function isValidTransactionFields(data) {
+      return data.name is string
         && data.name.size() > 0
         && data.name.size() <= 80
         && data.essence is string
@@ -106,6 +134,63 @@ service cloud.firestore {
         && isValidTransactionType(data.type)
         && isValidTransactionDate(data.transactionDate)
         && isValidInstallments(data);
+    }
+
+    function isValidTransactionMetadata(data) {
+      return (
+          !data.keys().hasAny(['updatedAt']) ||
+          data.updatedAt is timestamp
+        )
+        && (
+          !data.keys().hasAny(['duplicatedByUid']) ||
+          data.duplicatedByUid is string
+        )
+        && (
+          !data.keys().hasAny(['duplicatedAt']) ||
+          data.duplicatedAt is timestamp
+        )
+        && (
+          !data.keys().hasAny(['duplicatedFrom']) ||
+          (
+            data.duplicatedFrom is map
+            && data.duplicatedFrom.keys().hasOnly(['boardId', 'transactionId'])
+            && data.duplicatedFrom.keys().hasAll(['boardId', 'transactionId'])
+            && data.duplicatedFrom.boardId is string
+            && data.duplicatedFrom.transactionId is string
+          )
+        );
+    }
+
+    function isValidTransactionData(data) {
+      return data.keys().hasOnly(baseTransactionKeys())
+        && isValidTransactionFields(data);
+    }
+
+    function isValidTransactionDataWithMetadata(data) {
+      return data.keys().hasOnly(allowedTransactionKeys())
+        && isValidTransactionFields(data)
+        && isValidTransactionMetadata(data);
+    }
+
+    function preservesOptionalImmutableTransactionField(fieldName) {
+      return (
+          !resource.data.keys().hasAny([fieldName])
+          && !request.resource.data.keys().hasAny([fieldName])
+        )
+        || (
+          resource.data.keys().hasAny([fieldName])
+          && request.resource.data.keys().hasAny([fieldName])
+          && request.resource.data[fieldName] == resource.data[fieldName]
+        );
+    }
+
+    function preservesImmutableTransactionFields() {
+      return request.resource.data.createdByUid == resource.data.createdByUid
+        && request.resource.data.createdAt == resource.data.createdAt
+        && preservesOptionalImmutableTransactionField('updatedAt')
+        && preservesOptionalImmutableTransactionField('duplicatedFrom')
+        && preservesOptionalImmutableTransactionField('duplicatedByUid')
+        && preservesOptionalImmutableTransactionField('duplicatedAt');
     }
 
     match /boards/{boardId} {
@@ -131,9 +216,8 @@ service cloud.firestore {
         && request.resource.data.createdAt == request.time;
 
       allow update: if isBoardMember(boardId)
-        && isValidTransactionData(request.resource.data)
-        && request.resource.data.createdByUid == resource.data.createdByUid
-        && request.resource.data.createdAt == resource.data.createdAt;
+        && isValidTransactionDataWithMetadata(request.resource.data)
+        && preservesImmutableTransactionFields();
 
       allow delete: if isBoardMember(boardId);
     }

--- a/functions/index.js
+++ b/functions/index.js
@@ -618,6 +618,10 @@ exports.duplicateTransaction = onCall(
         throw new HttpsError('invalid-argument', 'sourceBoardId, destinationBoardId ו-transactionId נדרשים');
       }
 
+      if (sourceBoardId === destinationBoardId) {
+        throw new HttpsError('failed-precondition', 'לא ניתן לשכפל עסקה לאותו לוח');
+      }
+
       const sourceBoardRef = db.collection('boards').doc(sourceBoardId);
       const destinationBoardRef = db.collection('boards').doc(destinationBoardId);
       const sourceTxRef = sourceBoardRef.collection('transactions').doc(transactionId);
@@ -636,6 +640,10 @@ exports.duplicateTransaction = onCall(
         const sourceBoard = sourceBoardSnap.data();
         const destinationBoard = destinationBoardSnap.data();
         const isSuperBoard = (board) => Array.isArray(board?.subBoardIds) && board.subBoardIds.length > 0;
+
+        if (isSuperBoard(sourceBoard)) {
+          throw new HttpsError('failed-precondition', 'לא ניתן לשכפל עסקה מלוח-על');
+        }
 
         if (isSuperBoard(destinationBoard)) {
           throw new HttpsError('failed-precondition', 'לא ניתן לשכפל עסקה ללוח-על');

--- a/functions/index.js
+++ b/functions/index.js
@@ -595,6 +595,86 @@ exports.moveTransaction = onCall(
 );
 
 /**
+ * duplicateTransaction
+ *
+ * Duplicates a single transaction document from one board to another in a
+ * Firestore transaction. The source transaction is left unchanged and the
+ * duplicate receives a new generated document ID.
+ */
+exports.duplicateTransaction = onCall(
+    {enforceAppCheck: true},
+    async (request) => {
+      if (!request.auth) {
+        throw new HttpsError('unauthenticated', 'עליך להתחבר כדי לשכפל עסקה');
+      }
+
+      const uid = request.auth.uid;
+      const {sourceBoardId, destinationBoardId, transactionId} = request.data || {};
+      if (
+        typeof sourceBoardId !== 'string' || !sourceBoardId.trim() ||
+        typeof destinationBoardId !== 'string' || !destinationBoardId.trim() ||
+        typeof transactionId !== 'string' || !transactionId.trim()
+      ) {
+        throw new HttpsError('invalid-argument', 'sourceBoardId, destinationBoardId ו-transactionId נדרשים');
+      }
+
+      const sourceBoardRef = db.collection('boards').doc(sourceBoardId);
+      const destinationBoardRef = db.collection('boards').doc(destinationBoardId);
+      const sourceTxRef = sourceBoardRef.collection('transactions').doc(transactionId);
+      const destinationTxRef = destinationBoardRef.collection('transactions').doc();
+
+      await db.runTransaction(async (tx) => {
+        const [sourceBoardSnap, destinationBoardSnap, sourceTxSnap] = await Promise.all([
+          tx.get(sourceBoardRef),
+          tx.get(destinationBoardRef),
+          tx.get(sourceTxRef),
+        ]);
+
+        if (!sourceBoardSnap.exists) throw new HttpsError('not-found', 'לוח המקור לא נמצא');
+        if (!destinationBoardSnap.exists) throw new HttpsError('not-found', 'לוח היעד לא נמצא');
+
+        const sourceBoard = sourceBoardSnap.data();
+        const destinationBoard = destinationBoardSnap.data();
+        const isSuperBoard = (board) => Array.isArray(board?.subBoardIds) && board.subBoardIds.length > 0;
+
+        if (isSuperBoard(destinationBoard)) {
+          throw new HttpsError('failed-precondition', 'לא ניתן לשכפל עסקה ללוח-על');
+        }
+
+        if (!userHasBoardAccess(sourceBoard, uid) || !userHasBoardAccess(destinationBoard, uid)) {
+          throw new HttpsError('permission-denied', 'אין לך הרשאה לשכפל עסקה לאחד הלוחות שנבחרו');
+        }
+
+        if (!sourceTxSnap.exists) {
+          throw new HttpsError('not-found', 'העסקה לא נמצאה. ייתכן שהיא נמחקה');
+        }
+
+        const transactionData = sourceTxSnap.data();
+        tx.set(destinationTxRef, {
+          ...transactionData,
+          createdAt: admin.firestore.FieldValue.serverTimestamp(),
+          createdByUid: uid,
+          updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+          duplicatedFrom: {
+            boardId: sourceBoardId,
+            transactionId,
+          },
+          duplicatedByUid: uid,
+          duplicatedAt: admin.firestore.FieldValue.serverTimestamp(),
+        });
+      });
+
+      return {
+        success: true,
+        sourceBoardId,
+        destinationBoardId,
+        sourceTransactionId: transactionId,
+        duplicatedTransactionId: destinationTxRef.id,
+      };
+    },
+);
+
+/**
  * removeBoardMember
  *
  * Callable function that allows the board owner to remove a non-owner member

--- a/functions/package.json
+++ b/functions/package.json
@@ -2,7 +2,7 @@
   "name": "expense-management-functions",
   "description": "Firebase Cloud Functions for Expense Management",
   "private": true,
-  "version": "1.2.2",
+  "version": "1.3.0",
   "scripts": {
     "lint": "eslint .",
     "serve": "firebase emulators:start --only functions",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "expense-management",
   "private": true,
-  "version": "1.2.2",
+  "version": "1.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/deploy-preview.ps1
+++ b/scripts/deploy-preview.ps1
@@ -66,6 +66,9 @@ npm ci
 Write-Host "Installing function dependencies..."
 npm --prefix functions ci
 
+Write-Host "Building preview..."
+npx vite build --mode preview
+
 Write-Host "Deploying Firebase functions..."
 $jsonFunctionsOutputPath = Join-Path $firebaseDir "firebase-functions-output.json"
 firebase deploy --only functions `
@@ -78,9 +81,6 @@ Write-Host "Raw Firebase functions output saved to: $jsonFunctionsOutputPath"
 Write-Host "Deploying Firestore rules..."
 firebase deploy --only firestore:rules `
     --project $env:FIREBASE_PROJECT_ID
-
-Write-Host "Building preview..."
-npx vite build --mode preview
 
 Write-Host "Deploying Firebase preview channel: $channelId"
 $jsonPreviewOutputPath = Join-Path $firebaseDir "firebase-preview-output.json"

--- a/scripts/deploy-preview.ps1
+++ b/scripts/deploy-preview.ps1
@@ -75,6 +75,10 @@ firebase deploy --only functions `
 Write-Host ""
 Write-Host "Raw Firebase functions output saved to: $jsonFunctionsOutputPath"
 
+Write-Host "Deploying Firestore rules..."
+firebase deploy --only firestore:rules `
+    --project $env:FIREBASE_PROJECT_ID
+
 Write-Host "Building preview..."
 npx vite build --mode preview
 

--- a/src/components/TransactionCard.jsx
+++ b/src/components/TransactionCard.jsx
@@ -25,7 +25,7 @@ function formatTransactionDate(dateStr) {
   return `${String(day).padStart(2, '0')}/${String(month).padStart(2, '0')}/${year}`;
 }
 
-export function TransactionCard({ transaction, onEdit, onDelete, onMove }) {
+export function TransactionCard({ transaction, onEdit, onDelete, onMove, onDuplicate }) {
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState(null);
 
@@ -95,6 +95,17 @@ export function TransactionCard({ transaction, onEdit, onDelete, onMove }) {
             >
               <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 7h11m0 0l-3-3m3 3l-3 3M20 17H9m0 0l3-3m-3 3l3 3" />
+              </svg>
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => onDuplicate(transaction)}
+              title="שכפל עסקה"
+              aria-label="שכפל עסקה"
+            >
+              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 8V6a2 2 0 012-2h8a2 2 0 012 2v8a2 2 0 01-2 2h-2M6 8h8a2 2 0 012 2v8a2 2 0 01-2 2H6a2 2 0 01-2-2v-8a2 2 0 012-2z" />
               </svg>
             </Button>
             <Button

--- a/src/firebase/transactions.js
+++ b/src/firebase/transactions.js
@@ -112,3 +112,21 @@ export async function moveTransaction(sourceBoardId, destinationBoardId, transac
     throw new Error('אירעה שגיאה בעת העברת העסקה. נסה שוב.');
   }
 }
+
+/**
+ * Duplicate transaction to another board via secure callable function.
+ */
+export async function duplicateTransaction(sourceBoardId, destinationBoardId, transactionId) {
+  const fn = httpsCallable(functions, 'duplicateTransaction');
+  try {
+    const result = await fn({ sourceBoardId, destinationBoardId, transactionId });
+    return result.data;
+  } catch (err) {
+    const code = err?.code || '';
+    if (code === 'functions/unauthenticated') throw new Error('עליך להתחבר מחדש כדי לשכפל עסקה.');
+    if (code === 'functions/permission-denied') throw new Error('אין לך הרשאה לשכפל עסקה לאחד הלוחות שנבחרו.');
+    if (code === 'functions/not-found') throw new Error(err?.message || 'העסקה לא נמצאה. ייתכן שהיא נמחקה.');
+    if (code === 'functions/failed-precondition') throw new Error(err?.message || 'לא ניתן לשכפל את העסקה.');
+    throw new Error('אירעה שגיאה בעת שכפול העסקה. נסה שוב.');
+  }
+}

--- a/src/pages/BoardPage.jsx
+++ b/src/pages/BoardPage.jsx
@@ -15,6 +15,7 @@ import {useAuth} from '../context/AuthContext';
 import {
   addTransaction,
   deleteTransaction,
+  duplicateTransaction,
   getTransactionsForBoard,
   moveTransaction,
   updateTransaction
@@ -68,6 +69,7 @@ export function BoardPage() {
   const [exportingExcel, setExportingExcel] = useState(false);
   const [exportError, setExportError] = useState(null);
   const [moveSuccessMessage, setMoveSuccessMessage] = useState(null);
+  const [duplicateSuccessMessage, setDuplicateSuccessMessage] = useState(null);
   const [userNickname, setUserNickname] = useState('');
   /**
    * Active payment-method filter.
@@ -428,9 +430,20 @@ export function BoardPage() {
   const [moveDestinationBoardId, setMoveDestinationBoardId] = useState('');
   const [movingTransaction, setMovingTransaction] = useState(false);
   const [moveTransactionError, setMoveTransactionError] = useState(null);
+  const [duplicateTx, setDuplicateTx] = useState(null);
+  const [duplicateDestinationBoardId, setDuplicateDestinationBoardId] = useState('');
+  const [duplicatingTransaction, setDuplicatingTransaction] = useState(false);
+  const [duplicateTransactionError, setDuplicateTransactionError] = useState(null);
+
+  const isBoardSuperBoard = (candidate) => (candidate?.subBoardIds?.length ?? 0) > 0;
 
   const destinationBoards = useMemo(
     () => allBoards.filter((candidate) => candidate.id !== boardId),
+    [allBoards, boardId],
+  );
+
+  const duplicateDestinationBoards = useMemo(
+    () => allBoards.filter((candidate) => candidate.id !== boardId && !isBoardSuperBoard(candidate)),
     [allBoards, boardId],
   );
 
@@ -454,6 +467,29 @@ export function BoardPage() {
       setMoveTransactionError(err.message || 'אירעה שגיאה בעת העברת העסקה. נסה שוב.');
     } finally {
       setMovingTransaction(false);
+    }
+  }
+
+  function openDuplicateModal(transaction) {
+    setDuplicateTx(transaction);
+    setDuplicateDestinationBoardId('');
+    setDuplicateTransactionError(null);
+  }
+
+  async function handleDuplicateTransaction() {
+    if (!duplicateTx || !duplicateDestinationBoardId) return;
+    setDuplicatingTransaction(true);
+    setDuplicateTransactionError(null);
+    try {
+      await duplicateTransaction(boardId, duplicateDestinationBoardId, duplicateTx.id);
+      setDuplicateTx(null);
+      setDuplicateDestinationBoardId('');
+      setDuplicateSuccessMessage('העסקה שוכפלה בהצלחה.');
+      window.setTimeout(() => setDuplicateSuccessMessage(null), 3000);
+    } catch (err) {
+      setDuplicateTransactionError(err.message || 'אירעה שגיאה בעת שכפול העסקה. נסה שוב.');
+    } finally {
+      setDuplicatingTransaction(false);
     }
   }
 
@@ -621,6 +657,11 @@ export function BoardPage() {
         {moveSuccessMessage && (
           <div className="rounded-xl bg-emerald-50 dark:bg-emerald-900/30 border border-emerald-100 dark:border-emerald-800 px-4 py-3 text-sm text-emerald-700 dark:text-emerald-400">
             {moveSuccessMessage}
+          </div>
+        )}
+        {duplicateSuccessMessage && (
+          <div className="rounded-xl bg-emerald-50 dark:bg-emerald-900/30 border border-emerald-100 dark:border-emerald-800 px-4 py-3 text-sm text-emerald-700 dark:text-emerald-400">
+            {duplicateSuccessMessage}
           </div>
         )}
         {isSuperBoard ? (
@@ -798,6 +839,7 @@ export function BoardPage() {
                       key={tx.id}
                       transaction={tx}
                       onMove={openMoveModal}
+                      onDuplicate={openDuplicateModal}
                       onEdit={(tx) => setEditTx(tx)}
                       onDelete={handleDelete}
                     />
@@ -872,6 +914,47 @@ export function BoardPage() {
             <Button variant="secondary" onClick={() => setMoveTx(null)} disabled={movingTransaction}>ביטול</Button>
             <Button onClick={handleMoveTransaction} loading={movingTransaction} disabled={!moveDestinationBoardId || destinationBoards.length === 0}>
               {movingTransaction ? 'מעביר...' : 'העבר'}
+            </Button>
+          </div>
+        </div>
+      </Modal>
+
+
+
+      <Modal
+        isOpen={!!duplicateTx}
+        onClose={() => !duplicatingTransaction && setDuplicateTx(null)}
+        title="שכפול עסקה"
+      >
+        <div className="space-y-4">
+          <p className="text-sm text-gray-600 dark:text-gray-300">בחר לוח יעד שאליו העסקה תשוכפל.</p>
+          {duplicateDestinationBoards.length === 0 ? (
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              אין לוחות אחרים שניתן לשכפל אליהם את העסקה.
+            </p>
+          ) : (
+            <label className="block space-y-2">
+              <span className="text-sm text-gray-700 dark:text-gray-200">בחר לוח יעד</span>
+              <select
+                className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm dark:bg-gray-800 dark:border-gray-700"
+                value={duplicateDestinationBoardId}
+                onChange={(e) => setDuplicateDestinationBoardId(e.target.value)}
+                disabled={duplicatingTransaction}
+              >
+                <option value="">בחר...</option>
+                {duplicateDestinationBoards.map((candidate) => (
+                  <option key={candidate.id} value={candidate.id}>{candidate.title}</option>
+                ))}
+              </select>
+            </label>
+          )}
+          {duplicateTransactionError && (
+            <p className="text-sm text-red-500 dark:text-red-400" role="alert">{duplicateTransactionError}</p>
+          )}
+          <div className="flex justify-end gap-2">
+            <Button variant="secondary" onClick={() => setDuplicateTx(null)} disabled={duplicatingTransaction}>ביטול</Button>
+            <Button onClick={handleDuplicateTransaction} loading={duplicatingTransaction} disabled={!duplicateDestinationBoardId || duplicateDestinationBoards.length === 0}>
+              {duplicatingTransaction ? 'משכפל...' : 'שכפל'}
             </Button>
           </div>
         </div>


### PR DESCRIPTION
### Motivation
- Provide users the ability to copy an existing transaction into another board while keeping the original intact. 
- Reuse the existing secure server-side access/validation and the move-transaction UI/UX as a reference to ensure consistent permissions and Hebrew messaging.

### Description
- Added a new callable Cloud Function `duplicateTransaction` with App Check enforcement in `functions/index.js` that validates auth/args, checks source/destination boards and transaction existence, blocks super-board destinations, enforces board access, uses a Firestore transaction, creates a new destination doc via `destinationBoardRef.collection('transactions').doc()` and writes duplication metadata (`duplicatedFrom`, `duplicatedByUid`, `duplicatedAt`, `createdAt`, `createdByUid`, `updatedAt`).
- Added a frontend wrapper `duplicateTransaction(...)` in `src/firebase/transactions.js` that calls the callable and maps errors to duplication-specific Hebrew messages consistent with the `moveTransaction` style.
- Added a duplicate action button and `onDuplicate` prop to `src/components/TransactionCard.jsx` using a copy-style icon and Hebrew `title`/`aria-label` (`שכפל עסקה`).
- Wired the Board UI in `src/pages/BoardPage.jsx`: imported the wrapper, added duplicate-related state (`duplicateTx`, `duplicateDestinationBoardId`, `duplicatingTransaction`, `duplicateTransactionError`, `duplicateSuccessMessage`), filtered duplicate targets to exclude super-boards, provided `openDuplicateModal` / `handleDuplicateTransaction` flow which calls `duplicateTransaction`, resets modal state on success and shows the Hebrew success message `העסקה שוכפלה בהצלחה.`, and added the Hebrew modal UI with labels (`שכפול עסקה`, `בחר לוח יעד`, `ביטול`, `שכפל`, `משכפל...`).
- Kept existing move behavior untouched and preserved server-side access checks and App Check enforcement.

### Testing
- Ran `npm install` and `npm run build` (client build completed successfully).
- Installed function dependencies and ran `cd functions && npm install` and `cd functions && npm run lint` (lint completed; no blocking errors).
- Ran project linting `npm run lint` (completed without errors).
- All automated build and lint checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e4070a5a0832a99807befb630eabf)