### PR TITLE
Add multi-board transaction duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project are documented in this file.
 
 The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project follows [Semantic Versioning](https://semver.org/).
 
+## [1.4.0]
+
+### Added
+
+- Added support for duplicating a transaction to multiple destination boards in a single operation.
+- Replaced the duplicate transaction destination dropdown with a checkbox list, allowing users to select one or more eligible boards.
+- Added count-aware Hebrew success messaging for multi-board duplication.
+
+### Changed
+
+- Updated the transaction duplication callable to accept multiple destination board IDs while preserving backward compatibility with the previous single-board payload.
+- Updated duplicate transaction validation to normalize board IDs, reject duplicate destinations, reject same-board duplication, and limit the number of destination boards per request.
+- Improved the duplication flow to validate all selected boards before writing, keeping the operation all-or-nothing.
+
+### Fixed
+
+- Preserved backward compatibility for existing single-board `duplicateTransaction` helper calls.
+
 ## [1.3.0]
 
 ### Added

--- a/firestore.rules
+++ b/firestore.rules
@@ -52,15 +52,6 @@ service cloud.firestore {
       ];
     }
 
-    function transactionMetadataKeys() {
-      return [
-        'updatedAt',
-        'duplicatedFrom',
-        'duplicatedByUid',
-        'duplicatedAt',
-      ];
-    }
-
     function allowedTransactionKeys() {
       return [
         'name',

--- a/functions/index.js
+++ b/functions/index.js
@@ -615,19 +615,36 @@ exports.duplicateTransaction = onCall(
         destinationBoardIds,
         transactionId,
       } = request.data || {};
-      const normalizedDestinationBoardIds = Array.isArray(destinationBoardIds) ?
+      const MAX_DESTINATION_BOARDS = 50;
+      const rawDestinationBoardIds = Array.isArray(destinationBoardIds) ?
         destinationBoardIds :
         typeof destinationBoardId === 'string' ? [destinationBoardId] : [];
+      const normalizedSourceBoardId = typeof sourceBoardId === 'string' ?
+        sourceBoardId.trim() :
+        sourceBoardId;
+      const normalizedTransactionId = typeof transactionId === 'string' ?
+        transactionId.trim() :
+        transactionId;
+      const normalizedDestinationBoardIds = rawDestinationBoardIds.map(
+          (boardId) => typeof boardId === 'string' ? boardId.trim() : boardId,
+      );
 
       if (
-        typeof sourceBoardId !== 'string' || !sourceBoardId.trim() ||
-        typeof transactionId !== 'string' || !transactionId.trim()
+        typeof normalizedSourceBoardId !== 'string' || !normalizedSourceBoardId ||
+        typeof normalizedTransactionId !== 'string' || !normalizedTransactionId
       ) {
         throw new HttpsError('invalid-argument', 'sourceBoardId ו-transactionId נדרשים');
       }
 
       if (!normalizedDestinationBoardIds.length) {
         throw new HttpsError('invalid-argument', 'יש לבחור לפחות לוח יעד אחד');
+      }
+
+      if (normalizedDestinationBoardIds.length > MAX_DESTINATION_BOARDS) {
+        throw new HttpsError(
+            'invalid-argument',
+            `ניתן לשכפל עד ${MAX_DESTINATION_BOARDS} לוחות בפעולה אחת`,
+        );
       }
 
       const hasInvalidDestinationBoardId = normalizedDestinationBoardIds.some(
@@ -637,7 +654,7 @@ exports.duplicateTransaction = onCall(
         throw new HttpsError('invalid-argument', 'כל לוחות היעד חייבים להיות מזהים תקינים');
       }
 
-      if (normalizedDestinationBoardIds.includes(sourceBoardId)) {
+      if (normalizedDestinationBoardIds.includes(normalizedSourceBoardId)) {
         throw new HttpsError('failed-precondition', 'לא ניתן לשכפל עסקה לאותו לוח');
       }
 
@@ -645,8 +662,8 @@ exports.duplicateTransaction = onCall(
         throw new HttpsError('invalid-argument', 'לא ניתן לבחור את אותו לוח יעד יותר מפעם אחת');
       }
 
-      const sourceBoardRef = db.collection('boards').doc(sourceBoardId);
-      const sourceTxRef = sourceBoardRef.collection('transactions').doc(transactionId);
+      const sourceBoardRef = db.collection('boards').doc(normalizedSourceBoardId);
+      const sourceTxRef = sourceBoardRef.collection('transactions').doc(normalizedTransactionId);
       const destinationBoardRefs = normalizedDestinationBoardIds.map(
           (boardId) => db.collection('boards').doc(boardId),
       );
@@ -703,8 +720,8 @@ exports.duplicateTransaction = onCall(
             createdByUid: uid,
             updatedAt: admin.firestore.FieldValue.serverTimestamp(),
             duplicatedFrom: {
-              boardId: sourceBoardId,
-              transactionId,
+              boardId: normalizedSourceBoardId,
+              transactionId: normalizedTransactionId,
             },
             duplicatedByUid: uid,
             duplicatedAt: admin.firestore.FieldValue.serverTimestamp(),
@@ -714,9 +731,9 @@ exports.duplicateTransaction = onCall(
 
       return {
         success: true,
-        sourceBoardId,
+        sourceBoardId: normalizedSourceBoardId,
         destinationBoardIds: normalizedDestinationBoardIds,
-        sourceTransactionId: transactionId,
+        sourceTransactionId: normalizedTransactionId,
         duplicatedTransactions,
       };
     },

--- a/functions/index.js
+++ b/functions/index.js
@@ -609,47 +609,85 @@ exports.duplicateTransaction = onCall(
       }
 
       const uid = request.auth.uid;
-      const {sourceBoardId, destinationBoardId, transactionId} = request.data || {};
+      const {
+        sourceBoardId,
+        destinationBoardId,
+        destinationBoardIds,
+        transactionId,
+      } = request.data || {};
+      const normalizedDestinationBoardIds = Array.isArray(destinationBoardIds) ?
+        destinationBoardIds :
+        typeof destinationBoardId === 'string' ? [destinationBoardId] : [];
+
       if (
         typeof sourceBoardId !== 'string' || !sourceBoardId.trim() ||
-        typeof destinationBoardId !== 'string' || !destinationBoardId.trim() ||
         typeof transactionId !== 'string' || !transactionId.trim()
       ) {
-        throw new HttpsError('invalid-argument', 'sourceBoardId, destinationBoardId ו-transactionId נדרשים');
+        throw new HttpsError('invalid-argument', 'sourceBoardId ו-transactionId נדרשים');
       }
 
-      if (sourceBoardId === destinationBoardId) {
+      if (!normalizedDestinationBoardIds.length) {
+        throw new HttpsError('invalid-argument', 'יש לבחור לפחות לוח יעד אחד');
+      }
+
+      const hasInvalidDestinationBoardId = normalizedDestinationBoardIds.some(
+          (boardId) => typeof boardId !== 'string' || !boardId.trim(),
+      );
+      if (hasInvalidDestinationBoardId) {
+        throw new HttpsError('invalid-argument', 'כל לוחות היעד חייבים להיות מזהים תקינים');
+      }
+
+      if (normalizedDestinationBoardIds.includes(sourceBoardId)) {
         throw new HttpsError('failed-precondition', 'לא ניתן לשכפל עסקה לאותו לוח');
       }
 
+      if (new Set(normalizedDestinationBoardIds).size !== normalizedDestinationBoardIds.length) {
+        throw new HttpsError('invalid-argument', 'לא ניתן לבחור את אותו לוח יעד יותר מפעם אחת');
+      }
+
       const sourceBoardRef = db.collection('boards').doc(sourceBoardId);
-      const destinationBoardRef = db.collection('boards').doc(destinationBoardId);
       const sourceTxRef = sourceBoardRef.collection('transactions').doc(transactionId);
-      const destinationTxRef = destinationBoardRef.collection('transactions').doc();
+      const destinationBoardRefs = normalizedDestinationBoardIds.map(
+          (boardId) => db.collection('boards').doc(boardId),
+      );
+      const destinationTxRefs = destinationBoardRefs.map(
+          (boardRef) => boardRef.collection('transactions').doc(),
+      );
+      const duplicatedTransactions = destinationTxRefs.map((txRef, index) => ({
+        boardId: normalizedDestinationBoardIds[index],
+        transactionId: txRef.id,
+      }));
 
       await db.runTransaction(async (tx) => {
-        const [sourceBoardSnap, destinationBoardSnap, sourceTxSnap] = await Promise.all([
+        const [sourceBoardSnap, sourceTxSnap, ...destinationBoardSnaps] = await Promise.all([
           tx.get(sourceBoardRef),
-          tx.get(destinationBoardRef),
           tx.get(sourceTxRef),
+          ...destinationBoardRefs.map((boardRef) => tx.get(boardRef)),
         ]);
 
         if (!sourceBoardSnap.exists) throw new HttpsError('not-found', 'לוח המקור לא נמצא');
-        if (!destinationBoardSnap.exists) throw new HttpsError('not-found', 'לוח היעד לא נמצא');
+
+        const missingDestinationIndex = destinationBoardSnaps.findIndex((snap) => !snap.exists);
+        if (missingDestinationIndex !== -1) {
+          throw new HttpsError('not-found', 'אחד מלוחות היעד לא נמצא');
+        }
 
         const sourceBoard = sourceBoardSnap.data();
-        const destinationBoard = destinationBoardSnap.data();
+        const destinationBoards = destinationBoardSnaps.map((snap) => snap.data());
         const isSuperBoard = (board) => Array.isArray(board?.subBoardIds) && board.subBoardIds.length > 0;
 
         if (isSuperBoard(sourceBoard)) {
           throw new HttpsError('failed-precondition', 'לא ניתן לשכפל עסקה מלוח-על');
         }
 
-        if (isSuperBoard(destinationBoard)) {
+        if (destinationBoards.some((board) => isSuperBoard(board))) {
           throw new HttpsError('failed-precondition', 'לא ניתן לשכפל עסקה ללוח-על');
         }
 
-        if (!userHasBoardAccess(sourceBoard, uid) || !userHasBoardAccess(destinationBoard, uid)) {
+        const hasDestinationAccess = destinationBoards.every(
+            (board) => userHasBoardAccess(board, uid),
+        );
+        if (!userHasBoardAccess(sourceBoard, uid) || !hasDestinationAccess) {
           throw new HttpsError('permission-denied', 'אין לך הרשאה לשכפל עסקה לאחד הלוחות שנבחרו');
         }
 
@@ -658,26 +696,28 @@ exports.duplicateTransaction = onCall(
         }
 
         const transactionData = sourceTxSnap.data();
-        tx.set(destinationTxRef, {
-          ...transactionData,
-          createdAt: admin.firestore.FieldValue.serverTimestamp(),
-          createdByUid: uid,
-          updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-          duplicatedFrom: {
-            boardId: sourceBoardId,
-            transactionId,
-          },
-          duplicatedByUid: uid,
-          duplicatedAt: admin.firestore.FieldValue.serverTimestamp(),
+        destinationTxRefs.forEach((destinationTxRef) => {
+          tx.set(destinationTxRef, {
+            ...transactionData,
+            createdAt: admin.firestore.FieldValue.serverTimestamp(),
+            createdByUid: uid,
+            updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+            duplicatedFrom: {
+              boardId: sourceBoardId,
+              transactionId,
+            },
+            duplicatedByUid: uid,
+            duplicatedAt: admin.firestore.FieldValue.serverTimestamp(),
+          });
         });
       });
 
       return {
         success: true,
         sourceBoardId,
-        destinationBoardId,
+        destinationBoardIds: normalizedDestinationBoardIds,
         sourceTransactionId: transactionId,
-        duplicatedTransactionId: destinationTxRef.id,
+        duplicatedTransactions,
       };
     },
 );

--- a/functions/package.json
+++ b/functions/package.json
@@ -2,7 +2,7 @@
   "name": "expense-management-functions",
   "description": "Firebase Cloud Functions for Expense Management",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.4.0",
   "scripts": {
     "lint": "eslint .",
     "serve": "firebase emulators:start --only functions",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "expense-management",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/firebase/transactions.js
+++ b/src/firebase/transactions.js
@@ -116,10 +116,14 @@ export async function moveTransaction(sourceBoardId, destinationBoardId, transac
 /**
  * Duplicate transaction to another board via secure callable function.
  */
-export async function duplicateTransaction(sourceBoardId, destinationBoardIds, transactionId) {
+export async function duplicateTransaction(sourceBoardId, destinationBoardIdsOrId, transactionId) {
   const fn = httpsCallable(functions, 'duplicateTransaction');
+  const payload = Array.isArray(destinationBoardIdsOrId)
+    ? { sourceBoardId, destinationBoardIds: destinationBoardIdsOrId, transactionId }
+    : { sourceBoardId, destinationBoardId: destinationBoardIdsOrId, transactionId };
+
   try {
-    const result = await fn({ sourceBoardId, destinationBoardIds, transactionId });
+    const result = await fn(payload);
     return result.data;
   } catch (err) {
     const code = err?.code || '';

--- a/src/firebase/transactions.js
+++ b/src/firebase/transactions.js
@@ -116,10 +116,10 @@ export async function moveTransaction(sourceBoardId, destinationBoardId, transac
 /**
  * Duplicate transaction to another board via secure callable function.
  */
-export async function duplicateTransaction(sourceBoardId, destinationBoardId, transactionId) {
+export async function duplicateTransaction(sourceBoardId, destinationBoardIds, transactionId) {
   const fn = httpsCallable(functions, 'duplicateTransaction');
   try {
-    const result = await fn({ sourceBoardId, destinationBoardId, transactionId });
+    const result = await fn({ sourceBoardId, destinationBoardIds, transactionId });
     return result.data;
   } catch (err) {
     const code = err?.code || '';

--- a/src/pages/BoardPage.jsx
+++ b/src/pages/BoardPage.jsx
@@ -431,7 +431,7 @@ export function BoardPage() {
   const [movingTransaction, setMovingTransaction] = useState(false);
   const [moveTransactionError, setMoveTransactionError] = useState(null);
   const [duplicateTx, setDuplicateTx] = useState(null);
-  const [duplicateDestinationBoardId, setDuplicateDestinationBoardId] = useState('');
+  const [duplicateDestinationBoardIds, setDuplicateDestinationBoardIds] = useState([]);
   const [duplicatingTransaction, setDuplicatingTransaction] = useState(false);
   const [duplicateTransactionError, setDuplicateTransactionError] = useState(null);
 
@@ -472,19 +472,28 @@ export function BoardPage() {
 
   function openDuplicateModal(transaction) {
     setDuplicateTx(transaction);
-    setDuplicateDestinationBoardId('');
+    setDuplicateDestinationBoardIds([]);
     setDuplicateTransactionError(null);
   }
 
+  function toggleDuplicateDestinationBoard(boardId) {
+    setDuplicateDestinationBoardIds((current) =>
+      current.includes(boardId) ? current.filter((id) => id !== boardId) : [...current, boardId],
+    );
+  }
+
   async function handleDuplicateTransaction() {
-    if (!duplicateTx || !duplicateDestinationBoardId) return;
+    if (!duplicateTx || duplicateDestinationBoardIds.length === 0) return;
     setDuplicatingTransaction(true);
     setDuplicateTransactionError(null);
     try {
-      await duplicateTransaction(boardId, duplicateDestinationBoardId, duplicateTx.id);
+      const result = await duplicateTransaction(boardId, duplicateDestinationBoardIds, duplicateTx.id);
+      const duplicateCount = result?.duplicatedTransactions?.length || duplicateDestinationBoardIds.length;
       setDuplicateTx(null);
-      setDuplicateDestinationBoardId('');
-      setDuplicateSuccessMessage('העסקה שוכפלה בהצלחה.');
+      setDuplicateDestinationBoardIds([]);
+      setDuplicateSuccessMessage(
+        duplicateCount === 1 ? 'העסקה שוכפלה בהצלחה.' : `העסקה שוכפלה ל-${duplicateCount} לוחות בהצלחה.`,
+      );
       window.setTimeout(() => setDuplicateSuccessMessage(null), 3000);
     } catch (err) {
       setDuplicateTransactionError(err.message || 'אירעה שגיאה בעת שכפול העסקה. נסה שוב.');
@@ -923,37 +932,59 @@ export function BoardPage() {
 
       <Modal
         isOpen={!!duplicateTx}
-        onClose={() => !duplicatingTransaction && setDuplicateTx(null)}
+        onClose={() => {
+          if (!duplicatingTransaction) {
+            setDuplicateTx(null);
+            setDuplicateDestinationBoardIds([]);
+            setDuplicateTransactionError(null);
+          }
+        }}
         title="שכפול עסקה"
       >
         <div className="space-y-4">
-          <p className="text-sm text-gray-600 dark:text-gray-300">בחר לוח יעד שאליו העסקה תשוכפל.</p>
+          <p className="text-sm text-gray-600 dark:text-gray-300">בחר לוח יעד אחד או יותר שאליהם העסקה תשוכפל.</p>
           {duplicateDestinationBoards.length === 0 ? (
             <p className="text-sm text-gray-500 dark:text-gray-400">
               אין לוחות אחרים שניתן לשכפל אליהם את העסקה.
             </p>
           ) : (
-            <label className="block space-y-2">
-              <span className="text-sm text-gray-700 dark:text-gray-200">בחר לוח יעד</span>
-              <select
-                className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm dark:bg-gray-800 dark:border-gray-700"
-                value={duplicateDestinationBoardId}
-                onChange={(e) => setDuplicateDestinationBoardId(e.target.value)}
-                disabled={duplicatingTransaction}
-              >
-                <option value="">בחר...</option>
+            <div className="space-y-2">
+              <p className="text-sm text-gray-700 dark:text-gray-200">בחר לוחות יעד</p>
+              <div className="max-h-56 space-y-2 overflow-y-auto rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
                 {duplicateDestinationBoards.map((candidate) => (
-                  <option key={candidate.id} value={candidate.id}>{candidate.title}</option>
+                  <label
+                    key={candidate.id}
+                    className="flex cursor-pointer items-center gap-3 rounded-md px-2 py-2 text-sm text-gray-700 hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-gray-700/60"
+                  >
+                    <input
+                      type="checkbox"
+                      className="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+                      checked={duplicateDestinationBoardIds.includes(candidate.id)}
+                      onChange={() => toggleDuplicateDestinationBoard(candidate.id)}
+                      disabled={duplicatingTransaction}
+                    />
+                    <span>{candidate.title}</span>
+                  </label>
                 ))}
-              </select>
-            </label>
+              </div>
+            </div>
           )}
           {duplicateTransactionError && (
             <p className="text-sm text-red-500 dark:text-red-400" role="alert">{duplicateTransactionError}</p>
           )}
           <div className="flex justify-end gap-2">
-            <Button variant="secondary" onClick={() => setDuplicateTx(null)} disabled={duplicatingTransaction}>ביטול</Button>
-            <Button onClick={handleDuplicateTransaction} loading={duplicatingTransaction} disabled={!duplicateDestinationBoardId || duplicateDestinationBoards.length === 0}>
+            <Button
+              variant="secondary"
+              onClick={() => {
+                setDuplicateTx(null);
+                setDuplicateDestinationBoardIds([]);
+                setDuplicateTransactionError(null);
+              }}
+              disabled={duplicatingTransaction}
+            >
+              ביטול
+            </Button>
+            <Button onClick={handleDuplicateTransaction} loading={duplicatingTransaction} disabled={!duplicateTx || duplicateDestinationBoardIds.length === 0 || duplicateDestinationBoards.length === 0 || duplicatingTransaction}>
               {duplicatingTransaction ? 'משכפל...' : 'שכפל'}
             </Button>
           </div>


### PR DESCRIPTION
### Motivation
- Allow users to duplicate a single transaction into one or more regular boards in a single operation instead of repeating single-board calls. 
- Enforce server-side validation and prefer all-or-nothing behavior so no partial writes occur when any destination is invalid or inaccessible.
- Keep backward compatibility with the previous single-destination payload shape and preserve existing duplication security checks.

### Description
- Update the callable `duplicateTransaction` in `functions/index.js` to accept `destinationBoardIds` (array) while still supporting the old `destinationBoardId` string and normalize to an array via `normalizedDestinationBoardIds`.
- Add validation for authentication, `sourceBoardId`, `transactionId`, non-empty/unique/valid `destinationBoardIds`, disallow `sourceBoardId` in destinations, and preserve checks against super-boards and access control, keeping `enforceAppCheck: true`.
- Use a single Firestore transaction to `get` the source board, source transaction and all destination boards, validate all destinations, then create one new transaction document per destination with new generated IDs and the duplicated metadata fields (`createdAt`, `createdByUid`, `updatedAt`, `duplicatedFrom`, `duplicatedByUid`, `duplicatedAt`), and return `duplicatedTransactions` in the response.
- Update the client wrapper `src/firebase/transactions.js` to accept `destinationBoardIds` and send `{ sourceBoardId, destinationBoardIds, transactionId }` to the callable, and update `src/pages/BoardPage.jsx` to use array-based state (`duplicateDestinationBoardIds`), a `toggleDuplicateDestinationBoard` helper, a scrollable RTL-friendly checkbox list for eligible boards, reset selection on open/close, disable inputs during duplication, and show Hebrew success messages for single vs multiple duplicates.

### Testing
- Ran `npm run lint` at the repository root and it completed successfully.
- Built the frontend with `npm run build` and the Vite build completed successfully.
- Ran functions lint with `cd functions && npm run lint` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f47daf344832a93e8011bfc68395f)