### PR TITLE
Add board-scoped transaction filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project are documented in this file.
 
 The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project follows [Semantic Versioning](https://semver.org/).
 
+## [1.5.0]
+
+### Added
+
+- Added board-scoped transaction filters for business/name/notes search, exact date, payment method or credit card, and minimum/maximum amount.
+- Added live filtered-result counts and a single action for clearing all active filters.
+
+### Changed
+
+- Integrated the existing clickable payment totals with the new filter panel while keeping filters isolated to the currently opened regular board.
+
 ## [1.4.1]
 
 ### Fixed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,14 +6,15 @@ Security fixes are provided for the latest minor line only.
 
 | Version | Supported |
 |---------|:---------:|
-| 1.4.x   |    ✅     |
+| 1.5.x   |    ✅     |
+| 1.4.x   |    ❌     |
 | 1.3.x   |    ❌     |
 | 1.2.x   |    ❌     |
 | 1.1.x   |    ❌     |
 | 1.0.x   |    ❌     |
 | < 1.0.0 |    ❌     |
 
-If you run a self-hosted deployment, upgrade to the latest `1.4.x` patch release as soon as practical.
+If you run a self-hosted deployment, upgrade to the latest `1.5.x` patch release as soon as practical.
 
 ## Reporting a Vulnerability
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "expense-management",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "expense-management",
-      "version": "1.4.1",
+      "version": "1.5.0",
       "dependencies": {
         "firebase": "^12.11.0",
         "react": "^19.2.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "expense-management",
   "private": true,
-  "version": "1.4.1",
+  "version": "1.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/TransactionFilters.jsx
+++ b/src/components/TransactionFilters.jsx
@@ -1,0 +1,149 @@
+import {useId, useMemo, useState} from 'react';
+import {TRANSACTION_TYPE_LABELS} from '../constants/transactionTypes';
+import {
+  countActiveTransactionFilters,
+  EMPTY_TRANSACTION_FILTERS,
+  getTransactionPaymentFilterKey,
+} from '../utils/transactionFilters';
+import {Button} from './ui/Button';
+import {Input} from './ui/Input';
+
+function paymentFilterLabel(filterKey) {
+  if (filterKey.startsWith('card:')) {
+    const last4 = filterKey.slice(5);
+    return last4 ? 'כרטיס ****' + last4 : 'כרטיס אשראי ללא 4 ספרות';
+  }
+  if (filterKey.startsWith('type:')) {
+    const typeName = filterKey.slice(5);
+    return TRANSACTION_TYPE_LABELS[typeName] || typeName;
+  }
+  return filterKey;
+}
+
+export function TransactionFilters({filters, transactions, visibleCount, onChange}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const panelId = useId();
+  const activeFilterCount = countActiveTransactionFilters(filters);
+  const hasActiveFilters = activeFilterCount > 0;
+  const hasInvalidAmountRange =
+    filters.minAmount !== '' &&
+    filters.maxAmount !== '' &&
+    Number(filters.minAmount) > Number(filters.maxAmount);
+
+  const paymentOptions = useMemo(() => {
+    const keys = [...new Set(transactions.map(getTransactionPaymentFilterKey))];
+    return keys.sort((a, b) =>
+      paymentFilterLabel(a).localeCompare(paymentFilterLabel(b), 'he'),
+    );
+  }, [transactions]);
+
+  function setField(field, value) {
+    onChange({...filters, [field]: value});
+  }
+
+  return (
+    <section className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800">
+      <button
+        type="button"
+        className="flex w-full items-center justify-between gap-4 px-4 py-3 text-right transition-colors hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-400 dark:hover:bg-gray-700/60"
+        aria-expanded={isOpen}
+        aria-controls={panelId}
+        onClick={() => setIsOpen((open) => !open)}
+      >
+        <span className="flex min-w-0 items-center gap-2 text-sm font-semibold text-gray-700 dark:text-gray-200">
+          <svg className="h-4 w-4 shrink-0 text-indigo-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 4a1 1 0 011-1h16a1 1 0 01.8 1.6L14 13.67V19a1 1 0 01-.55.89l-4 2A1 1 0 018 21v-7.33L3.2 4.6A1 1 0 013 4z" />
+          </svg>
+          סינון עסקאות
+          {hasActiveFilters && (
+            <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-indigo-100 px-1.5 text-xs font-bold text-indigo-700 dark:bg-indigo-900/60 dark:text-indigo-300">
+              {activeFilterCount}
+            </span>
+          )}
+        </span>
+        <span className="flex shrink-0 items-center gap-3">
+          {hasActiveFilters && (
+            <span className="text-xs text-gray-500 dark:text-gray-400" aria-live="polite">
+              {visibleCount} מתוך {transactions.length}
+            </span>
+          )}
+          <svg className={'h-4 w-4 text-gray-400 transition-transform ' + (isOpen ? 'rotate-180' : '')} fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        </span>
+      </button>
+
+      {isOpen && (
+        <div id={panelId} className="border-t border-gray-100 px-4 py-4 dark:border-gray-700">
+          <div className="grid min-w-0 grid-cols-1 gap-4 sm:grid-cols-2">
+            <div className="sm:col-span-2">
+              <Input
+                label="שם העסק, שם או הערות"
+                type="search"
+                value={filters.query}
+                onChange={(event) => setField('query', event.target.value)}
+                placeholder="הקלד כדי לחפש..."
+              />
+            </div>
+            <Input
+              label="תאריך עסקה"
+              type="date"
+              max="9999-12-31"
+              value={filters.transactionDate}
+              onChange={(event) => setField('transactionDate', event.target.value)}
+            />
+            <div className="min-w-0 flex flex-col gap-1">
+              <label htmlFor={panelId + '-payment'} className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                אמצעי תשלום
+              </label>
+              <select
+                id={panelId + '-payment'}
+                value={filters.paymentMethod}
+                onChange={(event) => setField('paymentMethod', event.target.value)}
+                className="block w-full max-w-full min-w-0 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-900 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:focus:border-indigo-500 dark:focus:ring-indigo-900"
+              >
+                <option value="">כל אמצעי התשלום</option>
+                {paymentOptions.map((key) => (
+                  <option key={key} value={key}>{paymentFilterLabel(key)}</option>
+                ))}
+              </select>
+            </div>
+            <Input
+              label="סכום מינימלי"
+              type="number"
+              step="0.01"
+              inputMode="decimal"
+              value={filters.minAmount}
+              onChange={(event) => setField('minAmount', event.target.value)}
+              error={hasInvalidAmountRange ? 'הסכום המינימלי גבוה מהסכום המקסימלי' : undefined}
+            />
+            <Input
+              label="סכום מקסימלי"
+              type="number"
+              step="0.01"
+              inputMode="decimal"
+              value={filters.maxAmount}
+              onChange={(event) => setField('maxAmount', event.target.value)}
+            />
+          </div>
+          <div className="mt-4 flex flex-wrap items-center justify-between gap-3 border-t border-gray-100 pt-4 dark:border-gray-700">
+            <p className="text-xs text-gray-500 dark:text-gray-400" aria-live="polite">
+              {hasActiveFilters
+                ? 'מוצגות ' + visibleCount + ' מתוך ' + transactions.length + ' עסקאות'
+                : 'כל העסקאות בלוח מוצגות'}
+            </p>
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              disabled={!hasActiveFilters}
+              onClick={() => onChange({...EMPTY_TRANSACTION_FILTERS})}
+            >
+              נקה את כל המסננים
+            </Button>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/TransactionFilters.jsx
+++ b/src/components/TransactionFilters.jsx
@@ -31,11 +31,12 @@ export function TransactionFilters({filters, transactions, visibleCount, onChang
     Number(filters.minAmount) > Number(filters.maxAmount);
 
   const paymentOptions = useMemo(() => {
-    const keys = [...new Set(transactions.map(getTransactionPaymentFilterKey))];
-    return keys.sort((a, b) =>
+    const keys = new Set(transactions.map(getTransactionPaymentFilterKey));
+    if (filters.paymentMethod) keys.add(filters.paymentMethod);
+    return [...keys].sort((a, b) =>
       paymentFilterLabel(a).localeCompare(paymentFilterLabel(b), 'he'),
     );
-  }, [transactions]);
+  }, [transactions, filters.paymentMethod]);
 
   function setField(field, value) {
     onChange({...filters, [field]: value});

--- a/src/pages/BoardPage.jsx
+++ b/src/pages/BoardPage.jsx
@@ -37,12 +37,18 @@ import {Modal} from '../components/ui/Modal';
 import {ThemeToggle} from '../components/ui/ThemeToggle';
 import {TransactionForm} from '../components/TransactionForm';
 import {TransactionCard} from '../components/TransactionCard';
+import {TransactionFilters} from '../components/TransactionFilters';
 import {TotalsSummary} from '../components/TotalsSummary';
 import {CollaboratorManager} from '../components/CollaboratorManager';
 import {BoardHierarchyActionsMenu} from '../components/ui/BoardHierarchyActionsMenu';
 import {TRANSACTION_TYPE_LABELS} from '../constants/transactionTypes';
 import {subscribeWithAppCheckRetry} from '../utils/appCheckRetry';
 import {exportBoardToExcel} from '../utils/exportBoardToExcel';
+import {
+  countActiveTransactionFilters,
+  EMPTY_TRANSACTION_FILTERS,
+  filterTransactions,
+} from '../utils/transactionFilters';
 
 function formatAmount(amount) {
   return new Intl.NumberFormat('he-IL', { style: 'currency', currency: 'ILS' }).format(amount);
@@ -71,20 +77,19 @@ export function BoardPage() {
   const [moveSuccessMessage, setMoveSuccessMessage] = useState(null);
   const [duplicateSuccessMessage, setDuplicateSuccessMessage] = useState(null);
   const [userNickname, setUserNickname] = useState('');
-  /**
-   * Active payment-method filter.
-   * null  → no filter active
-   * string → a perGroup key, e.g. "card:1234" or "type:cash"
-   */
-  const [activePaymentFilter, setActivePaymentFilter] = useState({
+  const [transactionFilterState, setTransactionFilterState] = useState({
     boardId: null,
     routeKey: null,
-    key: null,
+    filters: EMPTY_TRANSACTION_FILTERS,
   });
+  const transactionFilters =
+    transactionFilterState.boardId === boardId &&
+    transactionFilterState.routeKey === location.key
+      ? transactionFilterState.filters
+      : EMPTY_TRANSACTION_FILTERS;
   const activePaymentFilterKey =
-    activePaymentFilter.boardId === boardId && activePaymentFilter.routeKey === location.key
-      ? activePaymentFilter.key
-      : null;
+    transactionFilters.paymentMethod || null;
+  const hasActiveTransactionFilters = countActiveTransactionFilters(transactionFilters) > 0;
   const board = boardState.boardId === boardId ? boardState.board : null;
   const boardLoading = boardState.boardId !== boardId ? true : boardState.loading;
   const boardError = boardState.boardId !== boardId ? null : boardState.error;
@@ -177,31 +182,27 @@ export function BoardPage() {
   );
 
   // ---------------------------------------------------------------------------
-  // Payment-method filter helpers
+  // Board-scoped transaction filter helpers
   // ---------------------------------------------------------------------------
 
-  /**
-   * Returns filtered transactions based on the active payment-method filter key.
-   * Uses the same null-coalescing as the totals hook (useTransactions) to ensure
-   * the filter key always matches what was used to build perGroup entries.
-   * key format: "card:XXXX" or "type:<typeName>"
-   */
   const visibleTransactions = useMemo(() => {
-    if (!activePaymentFilterKey) return transactions;
-    return transactions.filter((tx) => {
-      if (activePaymentFilterKey.startsWith('card:')) {
-        const last4 = activePaymentFilterKey.slice(5);
-        // Mirror the totals hook: `tx.cardLast4 ?? ''`
-        return tx.type === 'credit_card' && (tx.cardLast4 ?? '') === last4;
-      }
-      if (activePaymentFilterKey.startsWith('type:')) {
-        const typeName = activePaymentFilterKey.slice(5);
-        // Mirror the totals hook: `tx.type ?? 'unknown'`
-        return (tx.type ?? 'unknown') === typeName;
-      }
-      return false;
+    return filterTransactions(transactions, transactionFilters);
+  }, [transactions, transactionFilters]);
+
+  function handleTransactionFiltersChange(filters) {
+    setTransactionFilterState({boardId, routeKey: location.key, filters});
+  }
+
+  function handlePaymentFilterChange(key) {
+    handleTransactionFiltersChange({
+      ...transactionFilters,
+      paymentMethod: key ?? '',
     });
-  }, [transactions, activePaymentFilterKey]);
+  }
+
+  function clearTransactionFilters() {
+    handleTransactionFiltersChange({...EMPTY_TRANSACTION_FILTERS});
+  }
 
   /**
    * Derives the defaultPaymentMethod value for TransactionForm from an active
@@ -221,20 +222,6 @@ export function BoardPage() {
     }
     return undefined;
   }
-
-  /**
-   * Human-readable label for the active payment-method filter.
-   */
-  function paymentFilterLabel(filterKey) {
-    if (!filterKey) return '';
-    if (filterKey.startsWith('card:')) return `****${filterKey.slice(5)}`;
-    if (filterKey.startsWith('type:')) {
-      const typeName = filterKey.slice(5);
-      return TRANSACTION_TYPE_LABELS[typeName] || typeName;
-    }
-    return filterKey;
-  }
-
 
   const [removingSubBoardId, setRemovingSubBoardId] = useState(null);
   const [removeSubBoardError, setRemoveSubBoardError] = useState(null);
@@ -778,28 +765,16 @@ export function BoardPage() {
             <TotalsSummary
               totals={totals}
               activeFilterKey={activePaymentFilterKey}
-              onFilterChange={(key) => setActivePaymentFilter({ boardId, routeKey: location.key, key })}
+              onFilterChange={handlePaymentFilterChange}
             />
 
-            {/* Active payment-method filter indicator */}
-            {activePaymentFilterKey && (
-              <div className="flex items-center gap-2 rounded-xl bg-indigo-50 dark:bg-indigo-950/50 border border-indigo-200 dark:border-indigo-800 px-4 py-2 text-sm">
-                <span className="text-indigo-600 dark:text-indigo-400">
-                  מסונן לפי: <strong>{paymentFilterLabel(activePaymentFilterKey)}</strong>
-                </span>
-                <button
-                  type="button"
-                  onClick={() => setActivePaymentFilter({ boardId, routeKey: location.key, key: null })}
-                  className="mr-auto flex items-center gap-1 text-indigo-500 hover:text-indigo-700 dark:hover:text-indigo-300 transition-colors"
-                  aria-label="נקה סינון"
-                >
-                  <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                  </svg>
-                  נקה סינון
-                </button>
-              </div>
-            )}
+            <TransactionFilters
+              key={boardId + ':' + location.key}
+              filters={transactionFilters}
+              transactions={transactions}
+              visibleCount={visibleTransactions.length}
+              onChange={handleTransactionFiltersChange}
+            />
 
             {/* Transactions */}
             <div>
@@ -824,15 +799,15 @@ export function BoardPage() {
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z" />
                     </svg>
                   }
-                  title={activePaymentFilterKey ? 'אין עסקאות בסינון זה' : 'אין עסקאות עדיין'}
-                  description={activePaymentFilterKey ? 'אין עסקאות התואמות לאמצעי התשלום שנבחר' : 'הוסף את העסקה הראשונה כדי להתחיל לעקוב'}
+                  title={hasActiveTransactionFilters ? 'אין עסקאות התואמות לסינון' : 'אין עסקאות עדיין'}
+                  description={hasActiveTransactionFilters ? 'אפשר לשנות או לנקות את המסננים כדי לראות עסקאות נוספות' : 'הוסף את העסקה הראשונה כדי להתחיל לעקוב'}
                   action={
-                    activePaymentFilterKey ? (
+                    hasActiveTransactionFilters ? (
                       <Button
                         variant="secondary"
-                        onClick={() => setActivePaymentFilter({ boardId, routeKey: location.key, key: null })}
+                        onClick={clearTransactionFilters}
                       >
-                        נקה סינון
+                        נקה את כל המסננים
                       </Button>
                     ) : (
                       <Button onClick={() => setShowAddModal(true)}>

--- a/src/utils/transactionFilters.js
+++ b/src/utils/transactionFilters.js
@@ -1,0 +1,54 @@
+export const EMPTY_TRANSACTION_FILTERS = Object.freeze({
+  query: '',
+  transactionDate: '',
+  paymentMethod: '',
+  minAmount: '',
+  maxAmount: '',
+});
+
+function normalizeSearchValue(value) {
+  return String(value ?? '').normalize('NFKC').trim().toLocaleLowerCase('he-IL');
+}
+
+export function getTransactionPaymentFilterKey(transaction) {
+  return transaction.type === 'credit_card'
+    ? 'card:' + (transaction.cardLast4 ?? '')
+    : 'type:' + (transaction.type ?? 'unknown');
+}
+
+export function countActiveTransactionFilters(filters) {
+  return Object.values(filters).filter((value) => String(value ?? '').trim() !== '').length;
+}
+
+export function filterTransactions(transactions, filters) {
+  const query = normalizeSearchValue(filters.query);
+  const hasMinAmount = String(filters.minAmount ?? '').trim() !== '';
+  const hasMaxAmount = String(filters.maxAmount ?? '').trim() !== '';
+  const minAmount = Number(filters.minAmount);
+  const maxAmount = Number(filters.maxAmount);
+
+  return transactions.filter((transaction) => {
+    if (query) {
+      const searchableText = [transaction.essence, transaction.name, transaction.comment]
+        .map(normalizeSearchValue)
+        .join(' ');
+      if (!searchableText.includes(query)) return false;
+    }
+
+    if (
+      filters.transactionDate &&
+      transaction.transactionDate !== filters.transactionDate
+    ) return false;
+
+    if (
+      filters.paymentMethod &&
+      getTransactionPaymentFilterKey(transaction) !== filters.paymentMethod
+    ) return false;
+
+    const amount = Number(transaction.amount);
+    if (hasMinAmount && (!Number.isFinite(amount) || amount < minAmount)) return false;
+    if (hasMaxAmount && (!Number.isFinite(amount) || amount > maxAmount)) return false;
+
+    return true;
+  });
+}


### PR DESCRIPTION
## Summary

- add a collapsible transaction-filter panel only on regular board views
- filter the current board by business/name/notes text, exact date, payment method or credit card, and amount range
- keep the existing clickable payment totals synchronized with the new payment filter
- show active-filter and result counts, support clearing all filters, and reset filters when leaving the board
- bump the frontend release metadata and changelog to 1.5.0

## Verification

- `eslint .`
- `vite build`
- targeted Node assertions covering text, Hebrew text, exact-date, credit-card, transaction-type, amount-range, and combined filters
- `git diff --check`